### PR TITLE
feat(editor): add PDF creation/editing tool suite (11 new tools)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ semantic = [
     "numpy>=1.24",
 ]
 
+edit = [
+    "pypdf>=4.0",
+    "pillow>=10.0",
+    "reportlab>=4.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/jztan/pdf-mcp"
 Documentation = "https://github.com/jztan/pdf-mcp#readme"

--- a/src/pdf_mcp/edit_tools.py
+++ b/src/pdf_mcp/edit_tools.py
@@ -1,0 +1,419 @@
+"""
+pdf_mcp.edit_tools: MCP tool wrappers for PDF creation/manipulation.
+
+These tools are registered via register_edit_tools(mcp, pdf_config) called
+from server.py. Mirrors the read-side tools defined directly in server.py.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import FastMCP
+
+from . import editor
+from .config import PDFConfig
+
+
+def register_edit_tools(mcp: FastMCP, pdf_config: PDFConfig) -> None:
+    """
+    Register all PDF editing tools on the given FastMCP server.
+
+    Called once from server.py after the mcp instance is created.
+    """
+
+    @mcp.tool()
+    def pdf_from_images(
+        image_paths: list[str],
+        output_path: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Combine one or more images into a single PDF (one image = one page).
+
+        Supported formats: JPEG, PNG, BMP, TIFF, WebP. Images are converted
+        to RGB. Useful for assembling scanned documents (e.g. legal papers
+        photographed page-by-page) into a single PDF.
+
+        Args:
+            image_paths: Ordered list of image file paths. Each becomes a
+                page in the output PDF, in the order provided.
+            output_path: Path where the resulting PDF will be written. Must
+                end with .pdf. Parent directory must already exist.
+            overwrite: If False (default), raises if output_path already
+                exists. Set to True to replace.
+
+        Returns:
+            - output_path: Absolute path of the written PDF
+            - page_count: Number of pages in the resulting PDF
+            - input_count: Number of input images processed
+            - size_bytes: File size of the output PDF
+        """
+        try:
+            return editor.images_to_pdf(
+                image_paths=image_paths,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (
+            ValueError,
+            FileNotFoundError,
+            FileExistsError,
+        ) as exc:
+            return {
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            }
+
+    @mcp.tool()
+    def pdf_rename(
+        source: str,
+        destination: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Rename or move a PDF file on disk.
+
+        Args:
+            source: Path to the existing PDF.
+            destination: New path. Must end with .pdf. Parent directory
+                must already exist.
+            overwrite: If False (default), raises if destination exists.
+
+        Returns:
+            - source: Original absolute path
+            - destination: New absolute path
+            - size_bytes: File size after rename
+        """
+        try:
+            return editor.rename_pdf(
+                source=source,
+                destination=destination,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_merge(
+        input_paths: list[str],
+        output_path: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Merge multiple PDFs into a single PDF, in the order provided.
+
+        Args:
+            input_paths: Ordered list of PDF paths to concatenate.
+            output_path: Path for the merged PDF. Must end with .pdf.
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - output_path, input_count, total_pages
+            - page_counts_per_input: Pages in each input
+            - size_bytes
+        """
+        try:
+            return editor.merge_pdfs(
+                input_paths=input_paths,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_split(
+        source: str,
+        output_dir: str,
+        pages_per_file: int,
+        prefix: str = "part",
+    ) -> dict[str, Any]:
+        """
+        Split a PDF into chunks of N pages each.
+
+        Output files are named {prefix}_001.pdf, {prefix}_002.pdf, etc.
+
+        Args:
+            source: Path to the source PDF.
+            output_dir: Existing directory where chunks are written.
+            pages_per_file: Number of pages per chunk (>=1).
+            prefix: Filename prefix for chunks (default 'part').
+
+        Returns:
+            - output_files: List of paths written
+            - file_count, total_pages, pages_per_file
+        """
+        try:
+            return editor.split_pdf(
+                source=source,
+                output_dir=output_dir,
+                pages_per_file=pages_per_file,
+                pdf_config=pdf_config,
+                prefix=prefix,
+            )
+        except (
+            ValueError,
+            FileNotFoundError,
+            NotADirectoryError,
+        ) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_extract_pages(
+        source: str,
+        page_spec: str,
+        output_path: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Extract specific pages from a PDF into a new PDF.
+
+        Args:
+            source: Path to the source PDF.
+            page_spec: Page specification — same syntax as pdf_read_pages
+                ('1-10', '1,5,10', '1-5,10,15-20').
+            output_path: Path for the extracted-pages PDF (.pdf).
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - extracted_pages: List of 1-indexed pages copied
+            - page_count, output_path, size_bytes
+        """
+        try:
+            return editor.extract_pages(
+                source=source,
+                page_spec=page_spec,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_remove_pages(
+        source: str,
+        page_spec: str,
+        output_path: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Remove specified pages from a PDF, write the rest to a new PDF.
+
+        Args:
+            source: Path to the source PDF.
+            page_spec: Pages to remove (same syntax as pdf_read_pages).
+            output_path: Path for the trimmed PDF (.pdf).
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - removed_pages, kept_pages (both 1-indexed)
+            - page_count of result, output_path, size_bytes
+        """
+        try:
+            return editor.remove_pages(
+                source=source,
+                page_spec=page_spec,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_rotate_pages(
+        source: str,
+        page_spec: str,
+        angle: int,
+        output_path: str,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Rotate specified pages of a PDF by 90, 180, or 270 degrees.
+
+        Use page_spec='all' to rotate every page.
+
+        Args:
+            source: Path to the source PDF.
+            page_spec: Pages to rotate ('all', '1-3', '2,5', etc.).
+            angle: 90, 180, 270 (clockwise) or negatives (counter-clockwise).
+            output_path: Path for the rotated PDF.
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - rotated_pages (1-indexed), angle, output_path, size_bytes
+        """
+        try:
+            return editor.rotate_pages(
+                source=source,
+                page_spec=page_spec,
+                angle=angle,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_compress(
+        source: str,
+        output_path: str,
+        quality: str = "ebook",
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Compress a PDF using ghostscript.
+
+        Quality profiles:
+            screen   — 72 dpi, smallest file
+            ebook    — 150 dpi, balanced (default)
+            printer  — 300 dpi
+            prepress — 300 dpi, color preserving
+            default  — gs default
+
+        Args:
+            source: Path to the source PDF.
+            output_path: Path for the compressed PDF.
+            quality: One of 'screen', 'ebook', 'printer', 'prepress',
+                'default'.
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - quality_profile, original_size_bytes, compressed_size_bytes
+            - reduction_percent (negative if file grew)
+            - output_path
+        """
+        try:
+            return editor.compress_pdf(
+                source=source,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                quality=quality,
+                overwrite=overwrite,
+            )
+        except (
+            ValueError,
+            FileNotFoundError,
+            FileExistsError,
+            RuntimeError,
+        ) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_ocr(
+        source: str,
+        output_path: str,
+        languages: str = "ara+fra+eng",
+        force_ocr: bool = False,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Run OCR on a PDF using ocrmypdf.
+
+        Default languages 'ara+fra+eng' suit Tunisian legal documents.
+        Pages that already have text are skipped unless force_ocr=True.
+
+        Args:
+            source: Path to the source PDF.
+            output_path: Path for the OCR'd PDF.
+            languages: Tesseract language codes joined with '+'
+                (e.g. 'ara+fra+eng', 'eng', 'fra').
+            force_ocr: Re-OCR pages that already contain text.
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - languages, force_ocr, output_path, size_bytes
+            - ocrmypdf_exit_code (0 = clean, 6 = OK with warnings)
+        """
+        try:
+            return editor.ocr_pdf(
+                source=source,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                languages=languages,
+                force_ocr=force_ocr,
+                overwrite=overwrite,
+            )
+        except (
+            ValueError,
+            FileNotFoundError,
+            FileExistsError,
+            RuntimeError,
+        ) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_add_page_numbers(
+        source: str,
+        output_path: str,
+        position: str = "bottom-center",
+        start_at: int = 1,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Stamp page numbers onto each page of a PDF.
+
+        Args:
+            source: Path to the source PDF.
+            output_path: Path for the numbered PDF.
+            position: One of 'bottom-center', 'bottom-right', 'bottom-left',
+                'top-center', 'top-right', 'top-left'.
+            start_at: First page's number (default 1).
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - position, start_at, page_count, output_path, size_bytes
+        """
+        try:
+            return editor.add_page_numbers(
+                source=source,
+                output_path=output_path,
+                pdf_config=pdf_config,
+                position=position,
+                start_at=start_at,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}
+
+    @mcp.tool()
+    def pdf_add_watermark(
+        source: str,
+        output_path: str,
+        text: str,
+        opacity: float = 0.3,
+        font_size: int = 60,
+        overwrite: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Add a diagonal text watermark to every page of a PDF.
+
+        Args:
+            source: Path to the source PDF.
+            output_path: Path for the watermarked PDF.
+            text: Watermark text (e.g. 'COPIE', 'DRAFT', 'CONFIDENTIEL').
+            opacity: 0.0 (invisible) to 1.0 (opaque). Default 0.3.
+            font_size: Helvetica-Bold size in pt. Default 60.
+            overwrite: If False (default), raises if output_path exists.
+
+        Returns:
+            - watermark_text, opacity, font_size, page_count, output_path,
+              size_bytes
+        """
+        try:
+            return editor.add_watermark(
+                source=source,
+                output_path=output_path,
+                text=text,
+                pdf_config=pdf_config,
+                opacity=opacity,
+                font_size=font_size,
+                overwrite=overwrite,
+            )
+        except (ValueError, FileNotFoundError, FileExistsError) as exc:
+            return {"error": str(exc), "error_type": type(exc).__name__}

--- a/src/pdf_mcp/editor.py
+++ b/src/pdf_mcp/editor.py
@@ -1,0 +1,614 @@
+"""
+pdf_mcp.editor: PDF creation and manipulation primitives.
+
+Pure functions used by edit_tools.py. Mirrors the role of extractor.py
+for read-side operations.
+"""
+from __future__ import annotations
+
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from .config import PDFConfig
+from .extractor import parse_page_range
+
+SUPPORTED_IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".webp"}
+COMPRESS_QUALITIES = {"screen", "ebook", "printer", "prepress", "default"}
+PAGE_NUMBER_POSITIONS = {
+    "bottom-center", "bottom-right", "bottom-left",
+    "top-center", "top-right", "top-left",
+}
+
+
+def _resolve_input_image(path: str, pdf_config: PDFConfig) -> Path:
+    """Validate that path is an existing image and passes path policy."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    resolved = p.resolve()
+    if resolved.suffix.lower() not in SUPPORTED_IMAGE_EXTS:
+        raise ValueError(
+            f"Unsupported image extension {resolved.suffix}. "
+            f"Supported: {sorted(SUPPORTED_IMAGE_EXTS)}"
+        )
+    pdf_config.check_path(str(resolved))
+    if not resolved.exists():
+        raise FileNotFoundError(f"Image not found: {path}")
+    return resolved
+
+
+def _resolve_output_pdf(
+    path: str, pdf_config: PDFConfig, overwrite: bool
+) -> Path:
+    """Validate output PDF path: .pdf suffix, parent exists, policy passes."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    resolved = p.resolve()
+    if resolved.suffix.lower() != ".pdf":
+        raise ValueError(
+            f"Output must end with .pdf, got: {resolved.suffix}"
+        )
+    pdf_config.check_path(str(resolved))
+    if not resolved.parent.exists():
+        raise FileNotFoundError(
+            f"Parent directory does not exist: {resolved.parent}"
+        )
+    if resolved.exists() and not overwrite:
+        raise FileExistsError(
+            f"Output already exists: {resolved}. "
+            f"Set overwrite=True to replace."
+        )
+    return resolved
+
+
+def images_to_pdf(
+    image_paths: list[str],
+    output_path: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """
+    Combine one or more images (JPEG/PNG/BMP/TIFF/WebP) into a single PDF.
+
+    Each image becomes one page. Images are converted to RGB if needed.
+    Page size matches each image's pixel dimensions at 72 DPI.
+    """
+    from PIL import Image
+
+    if not image_paths:
+        raise ValueError("image_paths must contain at least one path")
+
+    resolved_inputs = [
+        _resolve_input_image(p, pdf_config) for p in image_paths
+    ]
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    rgb_images: list[Image.Image] = []
+    try:
+        for img_path in resolved_inputs:
+            img = Image.open(img_path)
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+            rgb_images.append(img)
+
+        first, rest = rgb_images[0], rgb_images[1:]
+        first.save(
+            output,
+            "PDF",
+            resolution=72.0,
+            save_all=True,
+            append_images=rest,
+        )
+    finally:
+        for img in rgb_images:
+            img.close()
+
+    return {
+        "output_path": str(output),
+        "page_count": len(resolved_inputs),
+        "input_count": len(resolved_inputs),
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def _resolve_pdf_input(path: str, pdf_config: PDFConfig) -> Path:
+    """Validate that path is an existing PDF and passes path policy."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    resolved = p.resolve()
+    if resolved.suffix.lower() != ".pdf":
+        raise ValueError(
+            f"Expected a .pdf file, got: {resolved.suffix}"
+        )
+    pdf_config.check_path(str(resolved))
+    if not resolved.exists():
+        raise FileNotFoundError(f"PDF not found: {path}")
+    return resolved
+
+
+def _resolve_output_dir(path: str, pdf_config: PDFConfig) -> Path:
+    """Validate output directory: exists, is a dir, passes policy."""
+    p = Path(path)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    resolved = p.resolve()
+    pdf_config.check_path(str(resolved))
+    if not resolved.exists():
+        raise FileNotFoundError(f"Directory does not exist: {resolved}")
+    if not resolved.is_dir():
+        raise NotADirectoryError(f"Not a directory: {resolved}")
+    return resolved
+
+
+def rename_pdf(
+    source: str,
+    destination: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Rename or move a PDF file."""
+    src = _resolve_pdf_input(source, pdf_config)
+    dst = _resolve_output_pdf(destination, pdf_config, overwrite)
+    src.rename(dst)
+    return {
+        "source": str(src),
+        "destination": str(dst),
+        "size_bytes": dst.stat().st_size,
+    }
+
+
+def merge_pdfs(
+    input_paths: list[str],
+    output_path: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Merge multiple PDFs into one (in given order)."""
+    from pypdf import PdfReader, PdfWriter
+
+    if not input_paths:
+        raise ValueError("input_paths must contain at least one path")
+
+    inputs = [_resolve_pdf_input(p, pdf_config) for p in input_paths]
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    writer = PdfWriter()
+    page_counts: list[int] = []
+    for in_path in inputs:
+        reader = PdfReader(str(in_path))
+        page_counts.append(len(reader.pages))
+        for page in reader.pages:
+            writer.add_page(page)
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "output_path": str(output),
+        "input_count": len(inputs),
+        "page_counts_per_input": page_counts,
+        "total_pages": sum(page_counts),
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def split_pdf(
+    source: str,
+    output_dir: str,
+    pages_per_file: int,
+    pdf_config: PDFConfig,
+    prefix: str = "part",
+) -> dict[str, Any]:
+    """Split a PDF into chunks of N pages each."""
+    from pypdf import PdfReader, PdfWriter
+
+    if pages_per_file < 1:
+        raise ValueError("pages_per_file must be >= 1")
+
+    src = _resolve_pdf_input(source, pdf_config)
+    out_dir = _resolve_output_dir(output_dir, pdf_config)
+
+    reader = PdfReader(str(src))
+    total = len(reader.pages)
+    files_written: list[str] = []
+
+    for chunk_idx, chunk_start in enumerate(range(0, total, pages_per_file)):
+        chunk_end = min(chunk_start + pages_per_file, total)
+        writer = PdfWriter()
+        for i in range(chunk_start, chunk_end):
+            writer.add_page(reader.pages[i])
+        out_file = out_dir / f"{prefix}_{chunk_idx + 1:03d}.pdf"
+        with open(out_file, "wb") as f:
+            writer.write(f)
+        files_written.append(str(out_file))
+
+    return {
+        "source": str(src),
+        "output_files": files_written,
+        "file_count": len(files_written),
+        "total_pages": total,
+        "pages_per_file": pages_per_file,
+    }
+
+
+def extract_pages(
+    source: str,
+    page_spec: str,
+    output_path: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Extract specific pages to a new PDF.
+
+    page_spec accepts the same syntax as pdf_read_pages:
+      "1-10", "1,5,10", "1-5,10,15-20"
+    """
+    from pypdf import PdfReader, PdfWriter
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    reader = PdfReader(str(src))
+    total = len(reader.pages)
+    page_nums = parse_page_range(page_spec, total)
+    if not page_nums:
+        raise ValueError(
+            f"No valid pages in spec '{page_spec}' "
+            f"for {total}-page document"
+        )
+
+    writer = PdfWriter()
+    for pn in page_nums:
+        writer.add_page(reader.pages[pn])
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "extracted_pages": [pn + 1 for pn in page_nums],
+        "page_count": len(page_nums),
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def remove_pages(
+    source: str,
+    page_spec: str,
+    output_path: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Remove specified pages, write remainder to new PDF."""
+    from pypdf import PdfReader, PdfWriter
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    reader = PdfReader(str(src))
+    total = len(reader.pages)
+    page_nums = parse_page_range(page_spec, total)
+    if not page_nums:
+        raise ValueError(
+            f"No valid pages in spec '{page_spec}' "
+            f"for {total}-page document"
+        )
+
+    pages_to_remove = set(page_nums)
+    if len(pages_to_remove) >= total:
+        raise ValueError(
+            "Cannot remove all pages; at least one page must remain"
+        )
+
+    writer = PdfWriter()
+    kept: list[int] = []
+    for i in range(total):
+        if i not in pages_to_remove:
+            writer.add_page(reader.pages[i])
+            kept.append(i + 1)
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "removed_pages": sorted(p + 1 for p in pages_to_remove),
+        "kept_pages": kept,
+        "page_count": len(kept),
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def rotate_pages(
+    source: str,
+    page_spec: str,
+    angle: int,
+    output_path: str,
+    pdf_config: PDFConfig,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Rotate specified pages by 90, 180, or 270 degrees.
+
+    page_spec="all" rotates every page.
+    """
+    from pypdf import PdfReader, PdfWriter
+
+    if angle not in (90, 180, 270, -90, -180, -270):
+        raise ValueError(
+            f"angle must be 90, 180, or 270 (or negatives), got {angle}"
+        )
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    reader = PdfReader(str(src))
+    total = len(reader.pages)
+
+    if page_spec == "all":
+        page_nums = list(range(total))
+    else:
+        page_nums = parse_page_range(page_spec, total)
+        if not page_nums:
+            raise ValueError(
+                f"No valid pages in spec '{page_spec}' "
+                f"for {total}-page document"
+            )
+
+    pages_to_rotate = set(page_nums)
+    writer = PdfWriter()
+    for i in range(total):
+        page = reader.pages[i]
+        if i in pages_to_rotate:
+            page.rotate(angle)
+        writer.add_page(page)
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "rotated_pages": [pn + 1 for pn in page_nums],
+        "angle": angle,
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def compress_pdf(
+    source: str,
+    output_path: str,
+    pdf_config: PDFConfig,
+    quality: str = "ebook",
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Compress a PDF using ghostscript.
+
+    Quality profiles (gs -dPDFSETTINGS):
+      screen   — 72 dpi, smallest
+      ebook    — 150 dpi, balanced (default)
+      printer  — 300 dpi
+      prepress — 300 dpi, color preserving
+      default  — gs default
+    """
+    if quality not in COMPRESS_QUALITIES:
+        raise ValueError(
+            f"quality must be one of {sorted(COMPRESS_QUALITIES)}, "
+            f"got '{quality}'"
+        )
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    cmd = [
+        "gs",
+        "-sDEVICE=pdfwrite",
+        "-dCompatibilityLevel=1.4",
+        f"-dPDFSETTINGS=/{quality}",
+        "-dNOPAUSE", "-dQUIET", "-dBATCH",
+        f"-sOutputFile={output}",
+        str(src),
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=300
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "ghostscript ('gs') not found. "
+            "Install via: apt install ghostscript"
+        ) from exc
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ghostscript failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+
+    src_size = src.stat().st_size
+    out_size = output.stat().st_size
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "quality_profile": quality,
+        "original_size_bytes": src_size,
+        "compressed_size_bytes": out_size,
+        "reduction_percent": (
+            round((1 - out_size / src_size) * 100, 2) if src_size > 0 else 0
+        ),
+    }
+
+
+def ocr_pdf(
+    source: str,
+    output_path: str,
+    pdf_config: PDFConfig,
+    languages: str = "ara+fra+eng",
+    force_ocr: bool = False,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Run OCR on a PDF using ocrmypdf.
+
+    Default languages 'ara+fra+eng' suit Tunisian legal documents.
+    Set force_ocr=True to OCR even pages that already have text.
+    """
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    cmd = ["ocrmypdf", "-l", languages]
+    if force_ocr:
+        cmd.append("--force-ocr")
+    else:
+        cmd.append("--skip-text")
+    cmd.extend([str(src), str(output)])
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=600
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            "ocrmypdf not found. Install via: apt install ocrmypdf"
+        ) from exc
+
+    # ocrmypdf success codes: 0 = OK, 6 = OK but had issues
+    if result.returncode not in (0, 6):
+        raise RuntimeError(
+            f"ocrmypdf failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "languages": languages,
+        "force_ocr": force_ocr,
+        "size_bytes": output.stat().st_size,
+        "ocrmypdf_exit_code": result.returncode,
+    }
+
+
+def add_page_numbers(
+    source: str,
+    output_path: str,
+    pdf_config: PDFConfig,
+    position: str = "bottom-center",
+    start_at: int = 1,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Stamp page numbers on each page using a reportlab overlay."""
+    from pypdf import PdfReader, PdfWriter
+    from reportlab.pdfgen.canvas import Canvas
+
+    if position not in PAGE_NUMBER_POSITIONS:
+        raise ValueError(
+            f"position must be one of {sorted(PAGE_NUMBER_POSITIONS)}, "
+            f"got '{position}'"
+        )
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    reader = PdfReader(str(src))
+    writer = PdfWriter()
+    margin = 36  # 0.5 inch
+
+    for idx, page in enumerate(reader.pages):
+        page_num = start_at + idx
+        w = float(page.mediabox.width)
+        h = float(page.mediabox.height)
+
+        buf = BytesIO()
+        c = Canvas(buf, pagesize=(w, h))
+        c.setFont("Helvetica", 10)
+        text = str(page_num)
+        text_w = c.stringWidth(text, "Helvetica", 10)
+
+        if position == "bottom-center":
+            x, y = (w - text_w) / 2, margin
+        elif position == "bottom-right":
+            x, y = w - text_w - margin, margin
+        elif position == "bottom-left":
+            x, y = margin, margin
+        elif position == "top-center":
+            x, y = (w - text_w) / 2, h - margin
+        elif position == "top-right":
+            x, y = w - text_w - margin, h - margin
+        else:  # top-left
+            x, y = margin, h - margin
+
+        c.drawString(x, y, text)
+        c.save()
+        buf.seek(0)
+
+        overlay = PdfReader(buf).pages[0]
+        writer.add_page(page)
+        writer.pages[-1].merge_page(overlay)
+
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "position": position,
+        "start_at": start_at,
+        "page_count": len(reader.pages),
+        "size_bytes": output.stat().st_size,
+    }
+
+
+def add_watermark(
+    source: str,
+    output_path: str,
+    text: str,
+    pdf_config: PDFConfig,
+    opacity: float = 0.3,
+    font_size: int = 60,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    """Add a diagonal text watermark to every page."""
+    from pypdf import PdfReader, PdfWriter
+    from reportlab.pdfgen.canvas import Canvas
+
+    if not text.strip():
+        raise ValueError("watermark text cannot be empty")
+    if not 0.0 <= opacity <= 1.0:
+        raise ValueError(f"opacity must be in [0.0, 1.0], got {opacity}")
+    if font_size <= 0:
+        raise ValueError(f"font_size must be > 0, got {font_size}")
+
+    src = _resolve_pdf_input(source, pdf_config)
+    output = _resolve_output_pdf(output_path, pdf_config, overwrite)
+
+    reader = PdfReader(str(src))
+    writer = PdfWriter()
+
+    for page in reader.pages:
+        w = float(page.mediabox.width)
+        h = float(page.mediabox.height)
+
+        buf = BytesIO()
+        c = Canvas(buf, pagesize=(w, h))
+        c.setFont("Helvetica-Bold", font_size)
+        c.setFillGray(0.5, opacity)
+        c.saveState()
+        c.translate(w / 2, h / 2)
+        c.rotate(45)
+        text_w = c.stringWidth(text, "Helvetica-Bold", font_size)
+        c.drawString(-text_w / 2, 0, text)
+        c.restoreState()
+        c.save()
+        buf.seek(0)
+
+        overlay = PdfReader(buf).pages[0]
+        writer.add_page(page)
+        writer.pages[-1].merge_page(overlay)
+
+    with open(output, "wb") as f:
+        writer.write(f)
+    return {
+        "source": str(src),
+        "output_path": str(output),
+        "watermark_text": text,
+        "opacity": opacity,
+        "font_size": font_size,
+        "page_count": len(reader.pages),
+        "size_bytes": output.stat().st_size,
+    }

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -20,6 +20,7 @@ from fastmcp.utilities.types import Image
 
 from .cache import PDFCache
 from .config import PDFConfig
+from .edit_tools import register_edit_tools
 from .extractor import (
     check_tesseract_available,
     estimate_tokens,
@@ -65,6 +66,9 @@ mcp = FastMCP(
 cache = PDFCache(ttl_hours=24)
 pdf_config = PDFConfig()
 url_fetcher = URLFetcher(config=pdf_config)
+
+# Register PDF editing tools (creation/manipulation)
+register_edit_tools(mcp, pdf_config)
 
 
 def _resolve_path(source: str) -> str:

--- a/tests/test_editor.py
+++ b/tests/test_editor.py
@@ -1,0 +1,404 @@
+# tests/test_editor.py
+"""Tests for pdf_mcp.editor module."""
+
+from pathlib import Path
+
+import pymupdf
+import pytest
+from PIL import Image
+
+from pdf_mcp.config import PDFConfig
+from pdf_mcp.editor import (
+    add_page_numbers,
+    add_watermark,
+    compress_pdf,
+    extract_pages,
+    images_to_pdf,
+    merge_pdfs,
+    ocr_pdf,
+    remove_pages,
+    rename_pdf,
+    rotate_pages,
+    split_pdf,
+)
+
+
+@pytest.fixture
+def pdf_config():
+    """Permissive config (no path restrictions)."""
+    return PDFConfig()
+
+
+@pytest.fixture
+def two_test_images(tmp_path):
+    """Create two test images of different formats and modes."""
+    a = tmp_path / "a.png"
+    b = tmp_path / "b.jpg"
+    Image.new("RGB", (800, 600), "red").save(a)
+    Image.new("RGB", (1000, 1400), "blue").save(b)
+    return [str(a), str(b)]
+
+
+@pytest.fixture
+def small_pdf(tmp_path):
+    """Create a 5-page PDF with text on each page."""
+    p = tmp_path / "small.pdf"
+    doc = pymupdf.open()
+    for i in range(5):
+        page = doc.new_page()
+        page.insert_text((50, 50), f"Page {i + 1} content")
+    doc.save(str(p))
+    doc.close()
+    return str(p)
+
+
+@pytest.fixture
+def two_pdfs(tmp_path):
+    """Create two PDFs (2 and 3 pages)."""
+    a = tmp_path / "a.pdf"
+    b = tmp_path / "b.pdf"
+
+    doc_a = pymupdf.open()
+    for i in range(2):
+        page = doc_a.new_page()
+        page.insert_text((50, 50), f"A page {i + 1}")
+    doc_a.save(str(a))
+    doc_a.close()
+
+    doc_b = pymupdf.open()
+    for i in range(3):
+        page = doc_b.new_page()
+        page.insert_text((50, 50), f"B page {i + 1}")
+    doc_b.save(str(b))
+    doc_b.close()
+
+    return str(a), str(b)
+
+
+class TestImagesToPdf:
+    """Tests for images_to_pdf."""
+
+    def test_basic_two_images(self, two_test_images, tmp_path, pdf_config):
+        out = tmp_path / "merged.pdf"
+        result = images_to_pdf(two_test_images, str(out), pdf_config)
+
+        assert Path(result["output_path"]).exists()
+        assert result["page_count"] == 2
+        assert result["input_count"] == 2
+        assert result["size_bytes"] > 0
+
+        doc = pymupdf.open(out)
+        try:
+            assert len(doc) == 2
+        finally:
+            doc.close()
+
+    def test_single_image(self, tmp_path, pdf_config):
+        img = tmp_path / "x.png"
+        Image.new("RGB", (400, 300), "green").save(img)
+        out = tmp_path / "single.pdf"
+
+        result = images_to_pdf([str(img)], str(out), pdf_config)
+
+        assert result["page_count"] == 1
+        doc = pymupdf.open(out)
+        try:
+            assert len(doc) == 1
+        finally:
+            doc.close()
+
+    def test_rgba_image_converted_to_rgb(self, tmp_path, pdf_config):
+        """RGBA images must be converted to RGB before PDF save."""
+        img = tmp_path / "transparent.png"
+        Image.new("RGBA", (200, 200), (255, 0, 0, 128)).save(img)
+        out = tmp_path / "rgba.pdf"
+
+        result = images_to_pdf([str(img)], str(out), pdf_config)
+        assert result["page_count"] == 1
+        assert Path(out).exists()
+
+    def test_grayscale_image_converted(self, tmp_path, pdf_config):
+        """Grayscale (mode 'L') images should also be converted."""
+        img = tmp_path / "gray.png"
+        Image.new("L", (200, 200), 128).save(img)
+        out = tmp_path / "gray.pdf"
+
+        result = images_to_pdf([str(img)], str(out), pdf_config)
+        assert result["page_count"] == 1
+
+    def test_empty_list_raises(self, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="at least one"):
+            images_to_pdf([], str(tmp_path / "out.pdf"), pdf_config)
+
+    def test_unsupported_extension_raises(self, tmp_path, pdf_config):
+        bad = tmp_path / "doc.txt"
+        bad.write_text("not an image")
+        with pytest.raises(ValueError, match="Unsupported image extension"):
+            images_to_pdf([str(bad)], str(tmp_path / "out.pdf"), pdf_config)
+
+    def test_missing_input_raises(self, tmp_path, pdf_config):
+        with pytest.raises(FileNotFoundError, match="Image not found"):
+            images_to_pdf(
+                [str(tmp_path / "nope.png")],
+                str(tmp_path / "out.pdf"),
+                pdf_config,
+            )
+
+    def test_output_must_be_pdf(self, two_test_images, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="must end with .pdf"):
+            images_to_pdf(
+                two_test_images,
+                str(tmp_path / "out.txt"),
+                pdf_config,
+            )
+
+    def test_overwrite_protection(self, two_test_images, tmp_path, pdf_config):
+        out = tmp_path / "merged.pdf"
+        images_to_pdf(two_test_images, str(out), pdf_config)
+
+        with pytest.raises(FileExistsError, match="overwrite=True"):
+            images_to_pdf(two_test_images, str(out), pdf_config)
+
+    def test_overwrite_true_replaces(self, two_test_images, tmp_path, pdf_config):
+        out = tmp_path / "merged.pdf"
+        images_to_pdf(two_test_images, str(out), pdf_config)
+        first_size = out.stat().st_size
+
+        # Overwrite with single image — should produce smaller PDF
+        single = [two_test_images[0]]
+        images_to_pdf(single, str(out), pdf_config, overwrite=True)
+        second_size = out.stat().st_size
+
+        # Different content → different size (or at least same file overwritten)
+        doc = pymupdf.open(out)
+        try:
+            assert len(doc) == 1  # Now single page
+        finally:
+            doc.close()
+        assert first_size != second_size or True  # may match by coincidence
+
+    def test_missing_parent_dir_raises(
+        self, two_test_images, tmp_path, pdf_config
+    ):
+        with pytest.raises(FileNotFoundError, match="Parent directory"):
+            images_to_pdf(
+                two_test_images,
+                str(tmp_path / "no" / "such" / "dir" / "out.pdf"),
+                pdf_config,
+            )
+
+    def test_page_order_preserved(self, tmp_path, pdf_config):
+        """First image stays first, regardless of dimensions."""
+        small = tmp_path / "small.png"
+        large = tmp_path / "large.png"
+        Image.new("RGB", (200, 200), "red").save(small)
+        Image.new("RGB", (1000, 1000), "blue").save(large)
+
+        out = tmp_path / "ordered.pdf"
+        images_to_pdf([str(small), str(large)], str(out), pdf_config)
+
+        doc = pymupdf.open(out)
+        try:
+            # Page 1 should match small image dimensions (200x200 px @ 72dpi)
+            assert doc[0].rect.width == pytest.approx(200, abs=1)
+            assert doc[1].rect.width == pytest.approx(1000, abs=1)
+        finally:
+            doc.close()
+
+
+class TestRenamePdf:
+    def test_basic_rename(self, small_pdf, tmp_path, pdf_config):
+        dst = tmp_path / "renamed.pdf"
+        result = rename_pdf(small_pdf, str(dst), pdf_config)
+        assert Path(result["destination"]).exists()
+        assert not Path(small_pdf).exists()
+        assert result["size_bytes"] > 0
+
+    def test_rename_protects_existing(self, small_pdf, tmp_path, pdf_config):
+        dst = tmp_path / "exists.pdf"
+        dst.write_bytes(b"%PDF-1.4\nfake")
+        with pytest.raises(FileExistsError):
+            rename_pdf(small_pdf, str(dst), pdf_config)
+
+    def test_rename_overwrite_true(self, small_pdf, tmp_path, pdf_config):
+        dst = tmp_path / "exists.pdf"
+        dst.write_bytes(b"%PDF-1.4\nfake")
+        rename_pdf(small_pdf, str(dst), pdf_config, overwrite=True)
+        # Real PDF now at dst
+        doc = pymupdf.open(str(dst))
+        try:
+            assert len(doc) == 5
+        finally:
+            doc.close()
+
+
+class TestMergePdfs:
+    def test_basic_merge(self, two_pdfs, tmp_path, pdf_config):
+        a, b = two_pdfs
+        out = tmp_path / "merged.pdf"
+        result = merge_pdfs([a, b], str(out), pdf_config)
+        assert result["total_pages"] == 5
+        assert result["page_counts_per_input"] == [2, 3]
+        doc = pymupdf.open(out)
+        try:
+            assert len(doc) == 5
+        finally:
+            doc.close()
+
+    def test_empty_list_raises(self, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="at least one"):
+            merge_pdfs([], str(tmp_path / "out.pdf"), pdf_config)
+
+
+class TestSplitPdf:
+    def test_split_into_chunks(self, small_pdf, tmp_path, pdf_config):
+        out_dir = tmp_path / "chunks"
+        out_dir.mkdir()
+        result = split_pdf(small_pdf, str(out_dir), 2, pdf_config)
+        # 5 pages, 2 per file → 3 files (2+2+1)
+        assert result["file_count"] == 3
+        assert all(Path(f).exists() for f in result["output_files"])
+
+    def test_pages_per_file_invalid(self, small_pdf, tmp_path, pdf_config):
+        out_dir = tmp_path / "chunks"
+        out_dir.mkdir()
+        with pytest.raises(ValueError, match="pages_per_file"):
+            split_pdf(small_pdf, str(out_dir), 0, pdf_config)
+
+    def test_split_missing_dir(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(FileNotFoundError):
+            split_pdf(small_pdf, str(tmp_path / "nope"), 2, pdf_config)
+
+
+class TestExtractPages:
+    def test_extract_range(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "extracted.pdf"
+        result = extract_pages(small_pdf, "1-3", str(out), pdf_config)
+        assert result["page_count"] == 3
+        assert result["extracted_pages"] == [1, 2, 3]
+
+    def test_extract_individual_pages(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "extracted.pdf"
+        result = extract_pages(small_pdf, "1,3,5", str(out), pdf_config)
+        assert result["extracted_pages"] == [1, 3, 5]
+
+    def test_extract_invalid_spec(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="No valid pages"):
+            extract_pages(
+                small_pdf, "abc", str(tmp_path / "out.pdf"), pdf_config
+            )
+
+
+class TestRemovePages:
+    def test_remove_some(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "trimmed.pdf"
+        result = remove_pages(small_pdf, "2,4", str(out), pdf_config)
+        assert result["page_count"] == 3
+        assert result["removed_pages"] == [2, 4]
+        assert result["kept_pages"] == [1, 3, 5]
+
+    def test_cannot_remove_all(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="Cannot remove all"):
+            remove_pages(
+                small_pdf, "1-5", str(tmp_path / "out.pdf"), pdf_config
+            )
+
+
+class TestRotatePages:
+    def test_rotate_all(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "rotated.pdf"
+        result = rotate_pages(small_pdf, "all", 90, str(out), pdf_config)
+        assert result["angle"] == 90
+        assert len(result["rotated_pages"]) == 5
+
+    def test_rotate_specific(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "rotated.pdf"
+        result = rotate_pages(small_pdf, "2,4", 180, str(out), pdf_config)
+        assert result["rotated_pages"] == [2, 4]
+
+    def test_invalid_angle(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="angle must"):
+            rotate_pages(
+                small_pdf, "all", 45, str(tmp_path / "out.pdf"), pdf_config
+            )
+
+
+@pytest.mark.integration
+class TestCompressPdf:
+    def test_basic_compress(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "compressed.pdf"
+        result = compress_pdf(small_pdf, str(out), pdf_config)
+        assert result["quality_profile"] == "ebook"
+        assert "reduction_percent" in result
+        assert Path(out).exists()
+
+    def test_invalid_quality(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="quality must"):
+            compress_pdf(
+                small_pdf,
+                str(tmp_path / "out.pdf"),
+                pdf_config,
+                quality="bogus",
+            )
+
+
+@pytest.mark.integration
+class TestOcrPdf:
+    def test_basic_ocr_skip_text(self, small_pdf, tmp_path, pdf_config):
+        """small_pdf has text — with skip-text default, ocrmypdf passes through."""
+        out = tmp_path / "ocred.pdf"
+        result = ocr_pdf(
+            small_pdf, str(out), pdf_config, languages="eng"
+        )
+        assert Path(out).exists()
+        assert result["languages"] == "eng"
+
+
+class TestAddPageNumbers:
+    def test_basic(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "numbered.pdf"
+        result = add_page_numbers(small_pdf, str(out), pdf_config)
+        assert result["position"] == "bottom-center"
+        assert result["page_count"] == 5
+        assert Path(out).exists()
+
+    def test_invalid_position(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="position must"):
+            add_page_numbers(
+                small_pdf,
+                str(tmp_path / "out.pdf"),
+                pdf_config,
+                position="middle",
+            )
+
+    def test_custom_start_at(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "numbered.pdf"
+        result = add_page_numbers(
+            small_pdf, str(out), pdf_config, start_at=10
+        )
+        assert result["start_at"] == 10
+
+
+class TestAddWatermark:
+    def test_basic(self, small_pdf, tmp_path, pdf_config):
+        out = tmp_path / "watermarked.pdf"
+        result = add_watermark(small_pdf, str(out), "DRAFT", pdf_config)
+        assert result["watermark_text"] == "DRAFT"
+        assert result["page_count"] == 5
+        assert Path(out).exists()
+
+    def test_empty_text_raises(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="cannot be empty"):
+            add_watermark(
+                small_pdf, str(tmp_path / "out.pdf"), "  ", pdf_config
+            )
+
+    def test_invalid_opacity(self, small_pdf, tmp_path, pdf_config):
+        with pytest.raises(ValueError, match="opacity"):
+            add_watermark(
+                small_pdf,
+                str(tmp_path / "out.pdf"),
+                "DRAFT",
+                pdf_config,
+                opacity=2.0,
+            )


### PR DESCRIPTION
## Summary

Adds a write-side companion module mirroring `extractor.py` for read-side ops. **11 new MCP tools** for PDF creation/manipulation, gated behind a new `[edit]` optional dep group.

## New tools

| Tool | Description |
| --- | --- |
| `pdf_from_images` | JPEG/PNG/BMP/TIFF/WebP → single PDF (one image = one page) |
| `pdf_rename` | Rename / move a PDF |
| `pdf_merge` | Concatenate multiple PDFs |
| `pdf_split` | Split into N-page chunks |
| `pdf_extract_pages` | Extract specific pages to a new PDF |
| `pdf_remove_pages` | Drop pages, keep the rest |
| `pdf_rotate_pages` | Rotate 90/180/270, per-page or all |
| `pdf_compress` | ghostscript profiles (screen/ebook/printer/prepress) |
| `pdf_ocr` | ocrmypdf, multi-lang (default `ara+fra+eng` for legal docs) |
| `pdf_add_page_numbers` | reportlab overlay, 6 positions |
| `pdf_add_watermark` | Diagonal text, opacity & font_size |

## Architecture

- `src/pdf_mcp/editor.py` — pure functions (mirrors `extractor.py`)
- `src/pdf_mcp/edit_tools.py` — exposes `register_edit_tools(mcp, pdf_config)`
- `server.py` — adds 3 lines: import + `register_edit_tools(mcp, pdf_config)` at init
- `pyproject.toml` — new `[edit]` optional dep group: `pypdf`, `pillow`, `reportlab`
- `pypdf` / `pillow` / `reportlab` are lazy-imported → core install stays lean
- All I/O paths route through `pdf_config.check_path()` — same policy as read-side

## System dependencies (subprocess, not Python deps)

- `ghostscript` — for `pdf_compress`
- `ocrmypdf` + `tesseract` — for `pdf_ocr`

## Test plan

- [x] `pytest tests/test_editor.py -v` → **37/37 passed**, 0 deprecation warnings
- [x] `compress_pdf` + `ocr_pdf` tests marked `@pytest.mark.integration`
- [x] Tool registration: `from pdf_mcp.server import mcp` → 19 tools (8 existing + 11 new)
- [x] No regression introduced by the 3-line addition to `server.py`
- [ ] CI to validate