### PR TITLE
fix(test): no-op Tesseract gate in OCR orchestration tests (green CI)

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2885,6 +2885,9 @@ class TestOcrParallelOrchestration:
 
         import pdf_mcp.server as srv
 
+        # No-op the Tesseract gate so this orchestration test runs in CI
+        # without the binary; the worker is mocked anyway.
+        monkeypatch.setattr(srv, "check_tesseract_available", lambda: None)
         monkeypatch.setattr(
             srv,
             "_ocr_page_worker",
@@ -2902,6 +2905,14 @@ class TestOcrParallelOrchestration:
     def test_ocr_response_shape_unchanged(self, isolated_server, tmp_path, monkeypatch):
         monkeypatch.setenv("PDF_MCP_MAX_WORKERS", "1")
         path = self._two_page_scanned(tmp_path)
+
+        import pdf_mcp.server as srv
+
+        # No-op Tesseract + mock the worker so the response-shape check runs in
+        # CI without the binary or real OCR.
+        monkeypatch.setattr(srv, "check_tesseract_available", lambda: None)
+        monkeypatch.setattr(srv, "_ocr_page_worker", lambda args: (args[1], "ocr text"))
+
         result = pdf_read_pages(path, "1-2", ocr=True)
         assert set(["pages", "total_chars", "cache_hits", "cache_misses"]).issubset(
             result.keys()


### PR DESCRIPTION
## Problem

`develop` CI is red: `TestOcrParallelOrchestration::test_ocr_failure_is_isolated_and_not_cached` and `::test_ocr_response_shape_unchanged` fail on the runners (no Tesseract installed).

Both call `pdf_read_pages(ocr=True)` without no-op'ing the Tesseract gate, so on a machine without the binary the OCR path returns the inline `{"error": "Tesseract not found"}` **before** reaching the parallel dispatch — failing the assertions. They passed locally only because Tesseract is installed. Lint/format/typecheck were green; tests-only failure.

## Fix

Patch `check_tesseract_available` to a no-op (and mock `_ocr_page_worker` in the shape test), mirroring how the existing `TestPdfReadPagesOcr` tests stay CI-safe. The tests now exercise the parallel-OCR orchestration logic without the binary or real OCR.

## Verification

- Both tests pass with Tesseract removed from `PATH`.
- 44 OCR/render orchestration tests green; black/flake8 clean.
- Audited every `ocr=True` test call site — all are now Tesseract-guarded (no-op patch in `test_server.py`, `skipif` in `test_integration.py`).