### PR TITLE
fix: accept password-protected PDFs in URL fetcher validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,10 +53,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (4) `url_fetcher` now structurally validates a downloaded PDF (opens cleanly,
   has pages, page content decompresses) with a retry-once loop, so a
   zlib-corrupt download is no longer cached and served indefinitely.
+- URL-fetched, password-protected PDFs are no longer false-rejected as
+  "truncated". `_validate_pdf_content()` checked the page count before the
+  encryption guard, but PDF 1.5+ object-stream layouts report zero pages until
+  authenticated, so a genuine encrypted PDF tripped the truncation check. It
+  now short-circuits on `doc.needs_pass` (more precise than `is_encrypted` —
+  owner-password-only PDFs still get full validation), and closes the document
+  via `finally` so the corrupt-PDF path no longer leaks it
+  ([#19](https://github.com/jztan/pdf-mcp/issues/19)).
 
 ### Contributors
 - @ebbsanchez — confirmed the bug on `develop` and supplied a minimal cache-only reproduction ([#17](https://github.com/jztan/pdf-mcp/issues/17))
-- @VooDisss — diagnosed and fixed the Windows OCR failures (tessdata detection, cache poisoning, pool timeout, PDF validation) ([#18](https://github.com/jztan/pdf-mcp/pull/18))
+- @VooDisss — diagnosed and fixed the Windows OCR failures (tessdata detection, cache poisoning, pool timeout, PDF validation) ([#18](https://github.com/jztan/pdf-mcp/pull/18)); root-caused the encrypted-PDF false-rejection and proposed the `needs_pass` short-circuit ([#19](https://github.com/jztan/pdf-mcp/issues/19))
 
 ## [1.19.1] - 2026-07-04
 ### Added

--- a/src/pdf_mcp/url_fetcher.py
+++ b/src/pdf_mcp/url_fetcher.py
@@ -51,27 +51,41 @@ def _validate_pdf_content(content: bytes, url: str) -> None:
 
     Raises PDFValidationError if the PDF cannot be opened, produces
     zero pages, or has no extractable content.
-    Encrypted PDFs pass validation but skip the content decompression
-    check (content is inaccessible without authentication).
+    Password-protected PDFs pass validation but skip the page-count and
+    decompression checks — the page tree and streams are inaccessible
+    without authentication, and PDF 1.5+ object-stream layouts report
+    zero pages until unlocked (issue #19).
     """
     try:
         doc = pymupdf.open(stream=content, filetype="pdf")
+    except Exception as exc:
+        raise PDFValidationError(
+            f"Downloaded PDF is corrupt and cannot be opened: {exc}"
+        ) from exc
+    try:
+        # Short-circuit password-protected PDFs before any page access:
+        # opening succeeded, which confirms a structurally valid PDF, but
+        # the page tree is unreadable without the password (and object-stream
+        # layouts read as zero pages, tripping the truncation check below).
+        # needs_pass is more precise than is_encrypted — owner-password-only
+        # PDFs auto-authenticate (needs_pass False) and still get full checks.
+        if doc.needs_pass:
+            return
         page_count = len(doc)
         if page_count == 0:
             raise PDFValidationError(
                 f"Downloaded PDF has zero pages — likely a truncated file: {url}"
             )
-        # Trigger deferred stream decompression (catches zlib corruption)
-        # but skip for encrypted PDFs — content is inaccessible without auth.
-        if not doc.is_encrypted:
-            doc[0].get_text()
-        doc.close()
+        # Trigger deferred stream decompression (catches zlib corruption).
+        doc[0].get_text()
     except PDFValidationError:
         raise
     except Exception as exc:
         raise PDFValidationError(
             f"Downloaded PDF is corrupt and cannot be opened: {exc}"
         ) from exc
+    finally:
+        doc.close()
 
 
 _BLOCKED_NETWORKS = (

--- a/tests/test_url_fetcher.py
+++ b/tests/test_url_fetcher.py
@@ -9,7 +9,11 @@ from unittest.mock import Mock, patch, MagicMock
 import pytest
 
 from pdf_mcp.config import PDFConfig
-from pdf_mcp.url_fetcher import URLFetcher
+from pdf_mcp.url_fetcher import (
+    PDFValidationError,
+    URLFetcher,
+    _validate_pdf_content,
+)
 
 
 @pytest.fixture
@@ -22,6 +26,7 @@ def url_fetcher(temp_cache_dir):
 def valid_pdf_bytes():
     """Valid PDF content (minimal single-page document)."""
     import pymupdf
+
     doc = pymupdf.open()
     doc.new_page(width=100, height=100)
     doc[0].insert_text((10, 10), "Test", fontsize=8)
@@ -758,3 +763,47 @@ class TestRedirectSSRFValidation:
 
                 with pytest.raises(ValueError, match="Too many redirects"):
                     url_fetcher.fetch(url)
+
+
+class TestValidatePDFContent:
+    """Direct tests for _validate_pdf_content structural validation."""
+
+    def test_valid_pdf_accepted(self, valid_pdf_bytes):
+        """A well-formed PDF passes validation without raising."""
+        _validate_pdf_content(valid_pdf_bytes, "https://example.com/ok.pdf")
+
+    def test_password_protected_pdf_accepted(self):
+        """A valid password-protected PDF is accepted, not rejected as
+        truncated (regression for #19).
+
+        PDF 1.5+ encrypted documents laid out with compressed object streams
+        read as zero pages until authenticated (``len(doc) == 0``), so a
+        page-count check ahead of the encryption guard false-rejects them as
+        "truncated". ``use_objstms=1`` forces that modern layout, which is the
+        format the bug actually triggers on.
+        """
+        import pymupdf
+
+        doc = pymupdf.open()
+        doc.new_page(width=100, height=100)
+        buf = doc.tobytes(
+            encryption=pymupdf.PDF_ENCRYPT_AES_256,
+            user_pw="secret",
+            use_objstms=1,
+        )
+        doc.close()
+
+        # Sanity-check the fixture reproduces #19's conditions: object-stream
+        # encrypted PDFs report zero pages and require a password.
+        probe = pymupdf.open(stream=buf, filetype="pdf")
+        assert probe.needs_pass and len(probe) == 0
+        probe.close()
+
+        # Must not raise — the document opened, which confirms it is a
+        # structurally valid PDF even though content needs a password.
+        _validate_pdf_content(buf, "https://example.com/enc.pdf")
+
+    def test_garbage_bytes_rejected(self):
+        """Non-PDF bytes that slip past the magic-byte check are rejected."""
+        with pytest.raises(PDFValidationError, match="corrupt"):
+            _validate_pdf_content(b"%PDF-1.4 not really a pdf", "https://x/y.pdf")


### PR DESCRIPTION
Closes #19.

## Problem

`_validate_pdf_content()` (added in #18) checks the page count *before* the encryption guard. PDF 1.5+ object-stream layouts report `len(doc) == 0` until authenticated, so a genuine password-protected PDF fetched by URL was false-rejected as a `"truncated file"` — a regression from the pre-#18 magic-byte-only behavior.

## Fix

- Short-circuit on `doc.needs_pass` before any page access. `needs_pass` is more precise than `is_encrypted`: owner-password-only PDFs auto-authenticate (`needs_pass` is `False`) and still get the full page-count + decompression validation.
- Wrap the validation in `try/finally: doc.close()` so the document no longer leaks when `get_text()` raises on the corrupt-PDF path (the case this validation targets). `open()` sits in its own `try` so a failed open never reaches the `finally` with an unbound `doc`.
- Correct the now-stale docstring.

## Test

New `TestValidatePDFContent` class. The regression test builds a real AES-256 PDF with `use_objstms=1` — I verified a classic-xref encrypted PDF does *not* reproduce the bug (`len(doc)` returns the true count); only the object-stream layout reads 0 pages. The test fails without the fix and asserts the fixture actually trips `needs_pass and len == 0`.

## Verification

- `pytest tests/test_url_fetcher.py tests/test_parallel.py` — 61 passed
- flake8 / black / mypy clean (pre-commit hooks passed on commit)

Credit to @VooDisss for root-causing this and proposing the `needs_pass` short-circuit.