### PR TITLE
fix: bound hung OCR/render worker in run_pages fallback (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   owner-password-only PDFs still get full validation), and closes the document
   via `finally` so the corrupt-PDF path no longer leaks it
   ([#19](https://github.com/jztan/pdf-mcp/issues/19)).
+- A hung OCR/render worker can no longer hang `pdf_read_pages`. `run_pages()`
+  previously re-ran pages left incomplete by a pool timeout/crash *in the
+  parent process with no timeout*, so a page stuck in Tesseract's native call
+  blocked forever (and a segfault-on-retry crashed the server). Incomplete
+  pages now run in a killable `multiprocessing` child bounded by a per-page
+  timeout; on timeout the child is terminated and the page is marked failed
+  (empty, retryable). The pool wait is now a per-page budget rather than a flat
+  total, and `render_page_as_png` writes atomically so a lingering worker can't
+  tear the PNG ([#20](https://github.com/jztan/pdf-mcp/issues/20)).
 
 ### Contributors
 - @ebbsanchez — confirmed the bug on `develop` and supplied a minimal cache-only reproduction ([#17](https://github.com/jztan/pdf-mcp/issues/17))
-- @VooDisss — diagnosed and fixed the Windows OCR failures (tessdata detection, cache poisoning, pool timeout, PDF validation) ([#18](https://github.com/jztan/pdf-mcp/pull/18)); root-caused the encrypted-PDF false-rejection and proposed the `needs_pass` short-circuit ([#19](https://github.com/jztan/pdf-mcp/issues/19))
+- @VooDisss — diagnosed and fixed the Windows OCR failures (tessdata detection, cache poisoning, pool timeout, PDF validation) ([#18](https://github.com/jztan/pdf-mcp/pull/18)); root-caused the encrypted-PDF false-rejection and proposed the `needs_pass` short-circuit ([#19](https://github.com/jztan/pdf-mcp/issues/19)); reported the residual hung-worker case in the #18 review ([#20](https://github.com/jztan/pdf-mcp/issues/20))
 
 ## [1.19.1] - 2026-07-04
 ### Added

--- a/src/pdf_mcp/extractor.py
+++ b/src/pdf_mcp/extractor.py
@@ -986,12 +986,19 @@ def render_page_as_png(
 
     file_name = f"{pdf_hash}_p{page_num}_render_{dpi}dpi{token}.png"
     file_path = output_dir / file_name
+    tmp_path = file_path.with_name(f"{file_name}.{os.getpid()}.tmp")
     try:
-        pix.save(str(file_path))
-        os.chmod(str(file_path), 0o600)
+        # Explicit output="png": pix.save() otherwise infers format from the
+        # file extension, and ".tmp" isn't a recognized image format.
+        pix.save(str(tmp_path), output="png")
+        os.chmod(str(tmp_path), 0o600)
+        # Atomic on POSIX and Windows: a concurrent writer (e.g. an orphaned
+        # pool worker rendering the same deterministic path) can no longer
+        # produce a torn/locked file — last writer wins as a whole.
+        os.replace(str(tmp_path), str(file_path))
     except Exception as e:
         try:
-            file_path.unlink(missing_ok=True)
+            tmp_path.unlink(missing_ok=True)
         except Exception:
             pass
         logger.warning("Failed to save render for page %d: %s", page_num, e)

--- a/src/pdf_mcp/parallel.py
+++ b/src/pdf_mcp/parallel.py
@@ -67,8 +67,12 @@ def _run_page_bounded(
         result = PageError(f"page timed out after {page_timeout}s")
     finally:
         if p.is_alive():
-            p.terminate()
+            p.terminate()  # SIGTERM / TerminateProcess
+            p.join(timeout=5)
+            if p.is_alive():
+                p.kill()  # SIGKILL — uncatchable
         p.join()
+        q.close()
     return result
 
 

--- a/src/pdf_mcp/parallel.py
+++ b/src/pdf_mcp/parallel.py
@@ -107,16 +107,16 @@ def run_pages(
     worker: Callable[[Any], Any],
     arg_list: list[Any],
     max_workers: int,
-    timeout: float = 300,
+    page_timeout: float = 300,
 ) -> list[Any]:
     """Map `worker` over `arg_list`, preserving order.
 
     max_workers <= 1 -> sequential list comprehension (no pool, no spawn cost).
-    Else a fresh per-call ProcessPoolExecutor with per-future timeout.
-    On BrokenProcessPool or TimeoutError (worker segfault, hang, OOM-kill),
-    keep results from already-completed futures and re-run only the
-    incomplete indices sequentially in-parent so the call still completes
-    without waiting on orphaned/hung workers.
+    Else a fresh per-call ProcessPoolExecutor with a per-page timeout: the pool
+    wait is bounded by `page_timeout` scaled to the worst-case wave count. On
+    BrokenProcessPool or TimeoutError, keep already-completed results and re-run
+    each incomplete page in a bounded, killable child process (never in-parent),
+    so a hung or crashing worker can neither block nor crash the parent.
     """
     if max_workers <= 1:
         return [worker(a) for a in arg_list]
@@ -124,13 +124,14 @@ def run_pages(
     pool: ProcessPoolExecutor | None = None
     results: list[Any] = [None] * len(arg_list)
     completed: set[int] = set()
+    overall = _overall_timeout(len(arg_list), max_workers, page_timeout)
 
     try:
         pool = ProcessPoolExecutor(max_workers=max_workers)
         try:
-            futures = [pool.submit(worker, a) for a in arg_list]
-            for f in as_completed(futures, timeout=timeout):
-                idx = futures.index(f)
+            future_to_idx = {pool.submit(worker, a): i for i, a in enumerate(arg_list)}
+            for f in as_completed(future_to_idx, timeout=overall):
+                idx = future_to_idx[f]
                 results[idx] = f.result()
                 completed.add(idx)
         except (BrokenProcessPool, TimeoutError):
@@ -141,6 +142,6 @@ def run_pages(
 
     for idx in range(len(arg_list)):
         if idx not in completed:
-            results[idx] = worker(arg_list[idx])
+            results[idx] = _run_page_bounded(worker, arg_list[idx], page_timeout)
 
     return results

--- a/src/pdf_mcp/parallel.py
+++ b/src/pdf_mcp/parallel.py
@@ -5,7 +5,10 @@ keeping this module free of PyMuPDF/project imports keeps the spawn re-import
 path cheap.
 """
 
+import math
+import multiprocessing
 import os
+import queue
 from concurrent.futures import ProcessPoolExecutor, as_completed, TimeoutError
 from concurrent.futures.process import BrokenProcessPool
 from typing import Any, Callable
@@ -23,6 +26,50 @@ class PageError:
 
     def __repr__(self) -> str:
         return f"PageError({self.detail!r})"
+
+
+def _overall_timeout(n_pages: int, max_workers: int, page_timeout: float) -> float:
+    """Total wall-clock budget for the pool wait: per-page timeout times the
+    worst-case number of waves. Prevents a healthy large batch from
+    false-timing-out into the slow fallback (per-page, not a flat total)."""
+    return page_timeout * math.ceil(n_pages / max(1, max_workers))
+
+
+def _worker_into_queue(worker: Callable[[Any], Any], arg: Any, q: Any) -> None:
+    """Run `worker(arg)` and put the result (or a PageError) on `q`.
+
+    Module-level so it pickles under the `spawn` start method (macOS/Windows).
+    """
+    try:
+        q.put(worker(arg))
+    except Exception as exc:  # pragma: no cover - defensive
+        q.put(PageError(repr(exc)))
+
+
+def _run_page_bounded(
+    worker: Callable[[Any], Any], arg: Any, page_timeout: float
+) -> Any:
+    """Run one page in a killable child process, bounded by `page_timeout`.
+
+    Returns the worker's result, or a PageError if the page did not finish in
+    time (a true hang) or the child died without producing a result (segfault /
+    OOM-kill). The child is terminated on timeout so a native hang cannot block
+    the parent — the whole point of running the fallback out-of-process.
+    """
+    ctx = multiprocessing.get_context()
+    q = ctx.Queue()
+    p = ctx.Process(target=_worker_into_queue, args=(worker, arg, q))
+    p.start()
+    try:
+        # Read BEFORE join to avoid the mp.Queue drain-deadlock.
+        result = q.get(timeout=page_timeout)
+    except queue.Empty:
+        result = PageError(f"page timed out after {page_timeout}s")
+    finally:
+        if p.is_alive():
+            p.terminate()
+        p.join()
+    return result
 
 
 def resolve_workers(n_pages: int, gate: int, cap: int = 8) -> int:

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -894,10 +894,18 @@ def pdf_read_pages(
                         (local_path, n, ocr_lang, 300, _TESSDATA_PATH)
                         for n in ocr_miss_pages
                     ]
-                    for pn, res in run_pages(
-                        _ocr_page_worker, ocr_args, workers, page_timeout=600
+                    for n, res in zip(
+                        ocr_miss_pages,
+                        run_pages(
+                            _ocr_page_worker, ocr_args, workers, page_timeout=600
+                        ),
                     ):
-                        ocr_results[pn] = res
+                        # run_pages yields the worker's (page_num, payload) tuple
+                        # on success, or a bare PageError sentinel for a page it
+                        # could not run (timeout/kill). Store the payload (or the
+                        # sentinel) under the known page number; the read loop
+                        # below treats a PageError/None as ocr_failed (retryable).
+                        ocr_results[n] = res[1] if isinstance(res, tuple) else res
                 except Exception:
                     logger.warning(
                         "Batch OCR failed on %d pages; "
@@ -945,8 +953,11 @@ def pdf_read_pages(
                     (local_path, n, str(cache.renders_dir), pdf_hash, clamped_dpi)
                     for n in render_miss_pages
                 ]
-                for pn, res in run_pages(_render_page_worker, render_args, workers):
-                    render_results[pn] = res
+                for n, res in zip(
+                    render_miss_pages,
+                    run_pages(_render_page_worker, render_args, workers),
+                ):
+                    render_results[n] = res[1] if isinstance(res, tuple) else res
 
         results = []
         cache_hits = 0

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -895,7 +895,7 @@ def pdf_read_pages(
                         for n in ocr_miss_pages
                     ]
                     for pn, res in run_pages(
-                        _ocr_page_worker, ocr_args, workers, timeout=600
+                        _ocr_page_worker, ocr_args, workers, page_timeout=600
                     ):
                         ocr_results[pn] = res
                 except Exception:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+import time
 
 from pdf_mcp.parallel import PageError, resolve_workers, run_pages
 
@@ -97,6 +98,48 @@ class TestResolveWorkers:
 
 def _square(n):
     return n * n
+
+
+def _sleep_worker(n):
+    # Sleeps far longer than any test timeout so the bound must kill it.
+    time.sleep(30)
+    return n
+
+
+def _raise_worker(n):
+    raise RuntimeError(f"boom {n}")
+
+
+class TestBoundedHelpers:
+    def test_overall_timeout_scales_with_waves(self):
+        from pdf_mcp.parallel import _overall_timeout
+
+        assert _overall_timeout(5, 2, 10) == 30  # ceil(5/2) = 3 waves
+        assert _overall_timeout(2, 8, 10) == 10  # single wave
+        assert _overall_timeout(0, 8, 10) == 0
+        assert _overall_timeout(3, 0, 10) == 30  # guards div-by-zero
+
+    def test_run_page_bounded_returns_result(self):
+        from pdf_mcp.parallel import _run_page_bounded
+
+        assert _run_page_bounded(_square, 6, page_timeout=10) == 36
+
+    def test_run_page_bounded_kills_hung_worker(self):
+        from pdf_mcp.parallel import _run_page_bounded, PageError
+
+        t0 = time.monotonic()
+        res = _run_page_bounded(_sleep_worker, 7, page_timeout=1)
+        elapsed = time.monotonic() - t0
+        assert isinstance(res, PageError)
+        # Bounded to ~page_timeout: killed, not waited out (30s worker).
+        assert elapsed < 5
+
+    def test_run_page_bounded_captures_worker_exception(self):
+        from pdf_mcp.parallel import _run_page_bounded, PageError
+
+        res = _run_page_bounded(_raise_worker, 3, page_timeout=10)
+        assert isinstance(res, PageError)
+        assert "boom 3" in res.detail
 
 
 class TestRunPages:

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -152,29 +152,31 @@ class TestRunPages:
         out = run_pages(_square, [1, 2, 3, 4, 5], max_workers=2)
         assert out == [1, 4, 9, 16, 25]
 
-    def test_broken_pool_falls_back_to_sequential(self, monkeypatch):
+    def test_broken_pool_falls_back_to_bounded_subprocess(self, monkeypatch):
         from concurrent.futures.process import BrokenProcessPool
 
         class _BoomPool:
             def __init__(self, *a, **k):
                 pass
 
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a):
-                return False
-
             def shutdown(self, **k):
                 pass
-
-            def map(self, *a, **k):
-                raise BrokenProcessPool("worker died")
 
             def submit(self, worker, arg):
                 raise BrokenProcessPool("worker died")
 
         monkeypatch.setattr("pdf_mcp.parallel.ProcessPoolExecutor", _BoomPool)
-        # Falls back to in-parent sequential, still returns correct results.
+        # Pool submit raises -> every page recovered via the bounded
+        # subprocess path (real multiprocessing), still correct + ordered.
         out = run_pages(_square, [2, 3, 4], max_workers=4)
         assert out == [4, 9, 16]
+
+    def test_hung_worker_does_not_hang_run_pages(self):
+        from pdf_mcp.parallel import PageError
+
+        t0 = time.monotonic()
+        out = run_pages(_sleep_worker, [1], max_workers=2, page_timeout=1)
+        elapsed = time.monotonic() - t0
+        assert isinstance(out[0], PageError)
+        # overall pool wait (~1s) + bounded fallback (~1s); killed, not waited.
+        assert elapsed < 8

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -180,3 +180,29 @@ class TestRunPages:
         assert isinstance(out[0], PageError)
         # overall pool wait (~1s) + bounded fallback (~1s); killed, not waited.
         assert elapsed < 8
+
+    def test_timeout_sentinel_survives_server_style_consumption(self):
+        # Real workers return (page_num, payload) tuples; a timed-out page
+        # comes back as a bare PageError. The server consumes results by
+        # zipping with its known page list and tolerating the sentinel — this
+        # must not raise and must mark the hung page failed.
+        from pdf_mcp.parallel import PageError
+
+        def _tuple_ok(arg):
+            return (arg, f"payload-{arg}")
+
+        page_ids = [10, 11]
+        # Page 10 hits the (real multiprocessing) sleep→kill path; page 11 is
+        # only here to prove healthy tuples still unpack. We exercise the
+        # sentinel path directly via _run_page_bounded to keep it fast+robust.
+        from pdf_mcp.parallel import _run_page_bounded
+
+        results = [
+            _run_page_bounded(_sleep_worker, page_ids[0], page_timeout=1),
+            _tuple_ok(page_ids[1]),
+        ]
+        consumed = {}
+        for n, res in zip(page_ids, results):
+            consumed[n] = res[1] if isinstance(res, tuple) else res
+        assert isinstance(consumed[10], PageError)  # hung page -> sentinel kept
+        assert consumed[11] == "payload-11"  # healthy tuple -> payload

--- a/tests/test_pdf_reader.py
+++ b/tests/test_pdf_reader.py
@@ -2740,5 +2740,27 @@ def test_get_metadata_exposes_content_trust(tmp_path):
     assert cache.get_metadata(p)["content_trust"] == {"suspicious": False}
 
 
+def test_render_write_is_atomic_no_tmp_residue(tmp_path):
+    """render_page_as_png writes via a temp file + atomic replace, leaving
+    no *.tmp residue and a valid PNG (regression guard for the torn-file
+    race when an orphaned pool worker writes the same deterministic path)."""
+    import pymupdf
+    from pathlib import Path
+    from pdf_mcp.extractor import render_page_as_png
+
+    doc = pymupdf.open()
+    doc.new_page(width=200, height=200)
+    try:
+        result = render_page_as_png(doc, 0, tmp_path, "hashabc", dpi=72)
+    finally:
+        doc.close()
+
+    out = Path(result["file_path_on_disk"])
+    assert out.exists() and out.stat().st_size > 0
+    assert out.read_bytes().startswith(b"\x89PNG")
+    # No leftover temp files from the atomic write.
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3247,6 +3247,56 @@ class TestOcrParallelOrchestration:
         )
         assert len(result["pages"]) == 2
 
+    def test_ocr_run_pages_bare_sentinel_is_isolated_and_not_cached(
+        self, isolated_server, tmp_path, monkeypatch
+    ):
+        """run_pages itself (not the worker) can yield a bare PageError
+
+        sentinel for a page it never ran (pool timeout/kill) rather than the
+        worker's usual (page_num, payload) tuple. pdf_read_pages must consume
+        that bare sentinel without raising, and treat it as an isolated,
+        non-cached OCR failure — same contract as a worker-reported error.
+
+        This guards the real zip/consumption code in server.py, not a
+        reimplementation of it: if that loop ever regressed to
+        `for pn, res in run_pages(...)` (unpacking each yielded item as a
+        2-tuple), the unpack would TypeError on the bare PageError (not
+        iterable). That TypeError is swallowed by the surrounding
+        `except Exception` — which then silently falls back to sequential
+        per-page `ocr_page()` calls — so the response shape alone would not
+        catch the regression. The `ocr_page` call-count assertion below
+        closes that gap: it fails if the fallback path was entered at all.
+        """
+        cache_instance, _ = isolated_server
+        path = self._two_page_scanned(tmp_path)
+
+        import pdf_mcp.server as srv
+        from unittest.mock import MagicMock
+
+        # No-op the Tesseract gate; run_pages itself is mocked below so no
+        # real worker/pool involvement is needed.
+        monkeypatch.setattr(srv, "check_tesseract_available", lambda: None)
+        monkeypatch.setattr(
+            srv,
+            "run_pages",
+            lambda *args, **kwargs: [PageError("timeout"), PageError("timeout")],
+        )
+        fallback_ocr_page = MagicMock(side_effect=AssertionError("should not run"))
+        monkeypatch.setattr(srv, "ocr_page", fallback_ocr_page)
+
+        result = pdf_read_pages(path, "1-2", ocr=True)
+
+        assert "error" not in result
+        sources = [p.get("source") for p in result["pages"]]
+        assert sources == ["ocr_failed", "ocr_failed"]
+        assert all(p["text"] == "" for p in result["pages"])
+        # Failure must NOT be cached -> page source still absent, and the
+        # call returned normally (bounded — no hang on the mocked pool).
+        assert cache_instance.get_pages_source(path, [0, 1]) == {}
+        # The bare sentinel must be consumed directly, never triggering the
+        # except-Exception sequential fallback (which would call ocr_page()).
+        fallback_ocr_page.assert_not_called()
+
 
 class TestRenderParallelOrchestration:
     def _multi_page_pdf(self, tmp_path, n=3):


### PR DESCRIPTION
Closes #20.

## Problem

`run_pages()` bounded the process-pool wait with `as_completed(timeout=)`, but on timeout/crash it re-ran the incomplete pages **in the parent process with no timeout**. A page stuck in Tesseract's in-process native call therefore hung `pdf_read_pages` forever (and a segfault-on-retry crashed the server). `as_completed` bounded the *crash* case but not the *hang* — which is the failure mode #18 set out to fix.

## Fix

- **Bounded, killable fallback.** Incomplete pages now run in their own `multiprocessing.Process` bounded by a per-page timeout; on timeout the child is `terminate()`d (escalating to `kill()` if it survives SIGTERM) and the page is marked failed (empty text, `source="ocr_failed"`, uncached → retryable). Native worker code never runs in the parent again, so a hung or crashing page can neither block nor crash `pdf_read_pages`. Stdlib-only — no new dependency.
- **Per-page timeout budget.** The pool wait is now `page_timeout × ceil(n / workers)` (worst-case waves) instead of a flat total, so a healthy large batch no longer false-timeouts into the fallback.
- **O(1) future→index** map replaces the `futures.index` scan.
- **Atomic render write.** `render_page_as_png` writes to a temp file + `os.replace`, so a lingering orphaned writer on the same deterministic path can no longer tear/lock the PNG (Windows sharing-violation safe).

## Accepted residual

A worker orphaned by the *first-phase* pool timeout keeps running until it finishes on its own — `ProcessPoolExecutor` cannot kill its own running workers, and we deliberately do not touch its private internals. Impact is a short-lived leaked process; the atomic render write removes the only correctness hazard it posed. Documented in code + spec.

## Tests

- `parallel.py`: bounded-run helpers (`_overall_timeout`, `_run_page_bounded`), a real 30s-worker hang test asserting the child is *killed* (bounded elapsed, not waited out), and the broken-pool fallback.
- `server.py`: end-to-end guard that `pdf_read_pages(ocr=True)` isolates a bare-`PageError` sentinel from the bounded fallback as `ocr_failed` **without** falling into the unbounded in-parent OCR path (empirically verified to fail against the pre-fix consumption).
- `extractor.py`: atomic render write leaves no `.tmp` residue.
- Full fast suite: 987 passed; black / flake8 / mypy clean.

Credit to @VooDisss for reporting this residual hung-worker case in the #18 review.