### PR TITLE
fix(chart): parse dash values written without a leading zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `pdf_extract_chart` no longer splits a single dashed curve into several
-  phantom series when the chart uses dash lengths below 1.
+  phantom series when the chart uses dash lengths below 1
+  ([#29](https://github.com/jztan/pdf-mcp/issues/29))
 
 ## [2.2.1] - 2026-08-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `pdf_extract_chart` no longer splits a single dashed curve into several
-  phantom series. Dash lengths below 1 are written without a leading zero
-  (`.4685312`), and the dash pattern was parsed as if the leading dot were
-  absent, so that value became `4685312`. The dash pattern is part of the
-  series style key, and that key rounds its numbers precisely so
-  floating-point noise between segments of one curve cannot separate them.
-  With the misparse, a difference in the 7th decimal survived rounding and
-  broke one curve into two.
+  phantom series when the chart uses dash lengths below 1.
 
 ## [2.2.1] - 2026-08-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+
+- `pdf_extract_chart` no longer splits a single dashed curve into several
+  phantom series. Dash lengths below 1 are written without a leading zero
+  (`.4685312`), and the dash pattern was parsed as if the leading dot were
+  absent, so that value became `4685312`. The dash pattern is part of the
+  series style key, and that key rounds its numbers precisely so
+  floating-point noise between segments of one curve cannot separate them.
+  With the misparse, a difference in the 7th decimal survived rounding and
+  broke one curve into two.
+
 ## [2.2.1] - 2026-08-22
 ### Fixed
 

--- a/src/pdf_mcp/chart_extractor.py
+++ b/src/pdf_mcp/chart_extractor.py
@@ -528,11 +528,20 @@ def _dash_key(d: dict[str, Any]) -> str | None:
     "sawtooth" chimera that traced neither real curve and, when the fit ran
     past the axis corner, dragged the whole panel into an out-of-range
     decline (consumer-found on Henighan Fig 16). Numbers are rounded so
-    float noise between segments of one curve cannot split it."""
+    float noise between segments of one curve cannot split it.
+
+    The alternation accepts a bare leading dot. PyMuPDF writes dash values
+    below 1 without a leading zero (e.g. ``[ 1.0834783 .4685312 ] 0``), and
+    a pattern requiring a digit before the point matched only the digits
+    after it, turning ``.4685312`` into ``4685312``. That inverted the
+    rounding this key depends on: two segments of one curve differing in
+    the 7th decimal became ``4685312.0`` vs ``4685319.0``, still distinct
+    after rounding, so a single dashed curve could split into phantom
+    series, exactly the failure the rounding is meant to prevent."""
     raw = d.get("dashes")
     if not raw or raw in ("[] 0", "[]0"):
         return None
-    nums = re.findall(r"-?\d+(?:\.\d+)?", str(raw))
+    nums = re.findall(r"-?(?:\d+(?:\.\d+)?|\.\d+)", str(raw))
     if not nums or all(float(n) == 0 for n in nums):
         return None
     return " ".join(f"{float(n):.1f}" for n in nums[:4])

--- a/tests/test_chart_extractor.py
+++ b/tests/test_chart_extractor.py
@@ -1357,3 +1357,34 @@ def test_dual_axis_exposes_right_axis():
     result2 = chart_extractor.extract_charts(doc2, 0)
     doc2.close()
     assert "y_axis_right" not in result2["charts"][0]
+
+
+def test_dash_key_parses_leading_dot_values():
+    """PyMuPDF writes dash values below 1 without a leading zero — real
+    output includes `[ 1.0834783 .4685312 ] 0`. The number pattern used to
+    require a digit before the decimal point, so it matched only the digits
+    *after* the dot and read `.4685312` as the integer 4685312.
+
+    That inverted the rounding `_dash_key` depends on. Its contract is that
+    numbers are rounded "so float noise between segments of one curve cannot
+    split it"; with the bug, two segments differing in the 7th decimal
+    became `4685312.0` vs `4685319.0` — still distinct after rounding — so a
+    single dashed curve could split into phantom series.
+    """
+    key = lambda raw: chart_extractor._dash_key({"dashes": raw})  # noqa: E731
+
+    # A leading dot must parse as a fraction, not as a large integer.
+    assert key("[ 1.0834783 .4685312 ] 0") == "1.1 0.5 0.0"
+    assert key("[ .5 .5 ] 0") == "0.5 0.5 0.0"
+
+    # Leading-dot and leading-zero spellings of the same pattern must not
+    # produce different style keys, or one curve splits by notation alone.
+    assert key("[ .5 .5 ] 0") == key("[ 0.5 0.5 ] 0")
+
+    # The noise tolerance the docstring promises must hold for sub-1 values.
+    assert key("[ 1.08 .4685312 ] 0") == key("[ 1.08 .4685319 ] 0")
+
+    # Unchanged behaviour for values >= 1 and for solid strokes.
+    assert key("[ 5.55 2.4 ] 0") == "5.5 2.4 0.0"
+    assert key("[] 0") is None
+    assert key("") is None


### PR DESCRIPTION
Fixes #29.

## Problem

`_dash_key()` parsed the dash pattern with `r"-?\d+(?:\.\d+)?"`, which
requires a digit before the decimal point. PyMuPDF writes dash lengths below
1 without a leading zero, so on real input like `[ 1.0834783 .4685312 ] 0`
the pattern matched only the digits after the dot and read `.4685312` as the
integer `4685312`.

The dash pattern is part of the series style key, and that key rounds its
numbers precisely so floating-point noise between segments of one curve
cannot separate them. The misparse inverted that: two segments differing in
the 7th decimal became `4685312.0` and `4685319.0`, still distinct after
rounding, so a single dashed curve could split into phantom series.

## Change

```diff
-re.findall(r"-?\d+(?:\.\d+)?", str(raw))
+re.findall(r"-?(?:\d+(?:\.\d+)?|\.\d+)", str(raw))
```

Values >= 1 and solid strokes are unaffected. Coordinates and axis
calibration were never involved; the defect was series grouping only.

## Test

`test_dash_key_parses_leading_dot_values` asserts:

- `.4685312` parses as a fraction, not as `4685312`
- leading-dot and leading-zero spellings of one pattern give the same key
- the documented noise tolerance holds for sub-1 values
- values >= 1 and solid strokes are unchanged

Verified the test fails without the source change (it produces
`1.1 4685312.0 0.0`) and passes with it. Full fast suite: 1585 passed.

## Notes

A fixture-backed end-to-end test would need a PDF whose dash values are
below 1 and written without a leading zero. The file that exposed this
(`1302.4245.pdf`) lives under the gitignored `.reading_order_pdfs/`, so it
cannot back a committed test. The regression is unit-level for that reason.

Found while tracing an unrelated dash-array mismatch; the defect is in
shipped code and independent of that work.
