### PR TITLE
feat(corpus_search): document-level routing arm for hybrid corpus search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never made the page shortlist can still reach `matches` and
   `doc_match_counts`. On a 500-document corpus (100 graded arXiv papers
   plus 400 distractors) described-query doc-hit@3 went from 0.48 to
-  0.68, with needle and trap unchanged at 1.000 and 0.985; at 100
-  documents described doc-hit@3 went from 0.64 to 0.72 (spread eased
-  back from 0.92 to 0.88 on one query, as predicted). Hybrid matches
-  carry `doc_score`, and the response carries `doc_profile_coverage`.
-  Profiles are written by `pdf_corpus_warm(embeddings=True)` and
-  backfilled from cached text on first search, so existing caches need
-  no re-warm.
+  0.68 and spread from 0.64 to 0.72, with needle and trap unchanged at
+  1.000 and 0.985; the keyword and semantic arms scored identically,
+  query for query, between the pre-arm and post-arm runs, which is the
+  control that makes the gain credible. At 100 documents, described
+  doc-hit@3 sits in a two-query band across same-day re-runs (0.64 to
+  0.72); spread eased from 0.92 to 0.88 on one query, and needle and
+  trap were unchanged. Hybrid matches carry `doc_score`, and the
+  response carries `doc_profile_coverage`. Profiles are written by
+  `pdf_corpus_warm(embeddings=True)` and backfilled from cached text on
+  first search, so existing caches need no re-warm.
 - **`pdf_corpus_overview` cards carry `about`**: up to eight of the
   document's most distinctive terms relative to the corpus.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- **`pdf_corpus_search` hybrid mode now ranks documents, not only pages.**
+  A cached per-document head vector (page 1, first 1,500 characters,
+  same embedding model as pages) is fused as a third, lower-weight arm
+  beside the keyword and semantic page arms, so a document whose pages
+  never made the page shortlist can still reach `matches` and
+  `doc_match_counts`. On a 500-document corpus (100 graded arXiv papers
+  plus 400 distractors) described-query doc-hit@3 went from 0.48 to
+  0.68, with needle and trap unchanged at 1.000 and 0.985; at 100
+  documents described doc-hit@3 went from 0.64 to 0.72 (spread eased
+  back from 0.92 to 0.88 on one query, as predicted). Hybrid matches
+  carry `doc_score`, and the response carries `doc_profile_coverage`.
+  Profiles are written by `pdf_corpus_warm(embeddings=True)` and
+  backfilled from cached text on first search, so existing caches need
+  no re-warm.
+- **`pdf_corpus_overview` cards carry `about`**: up to eight of the
+  document's most distinctive terms relative to the corpus.
+
 ### Changed
 
 - **Browser demo redesigned** (pdf-mcp.jztan.com). New layout and visual

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   0.68 and spread from 0.64 to 0.72, with needle and trap unchanged at
   1.000 and 0.985; the keyword and semantic arms scored identically,
   query for query, between the pre-arm and post-arm runs, which is the
-  control that makes the gain credible. At 100 documents, described
-  doc-hit@3 sits in a two-query band across same-day re-runs (0.64 to
-  0.72); spread eased from 0.92 to 0.88 on one query, and needle and
-  trap were unchanged. Hybrid matches carry `doc_score`, and the
+  control that makes the gain credible. A corpus-size sweep from 50 to 500
+  documents (`benchmark_data/corpus_search/doc_arm_size_sweep.md`) shows
+  the same picture at every size: described doc-hit@3 holds at 0.64 to
+  0.72 with the arm where it decays from 0.64 to 0.48 without it, needle
+  and trap never move, and the arm's only recurring cost is one spread
+  query at 100 documents or fewer (a paper found only by a keyword deep
+  inside it, whose abstract is about something else). Hybrid matches carry `doc_score`, and the
   response carries `doc_profile_coverage`. Profiles are written by
   `pdf_corpus_warm(embeddings=True)` and backfilled from cached text on
   first search, so existing caches need no re-warm.

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.json
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.json
@@ -6827,5 +6827,1383 @@
     "described-12"
    ]
   }
+ },
+ "size50": {
+  "20260829": {
+   "n_eligible": 37,
+   "eligible_ids": [
+    "needle-02",
+    "needle-05",
+    "needle-07",
+    "needle-09",
+    "needle-10",
+    "needle-11",
+    "spread-05",
+    "trap-04",
+    "trap-05",
+    "trap-06",
+    "trap-07",
+    "trap-11",
+    "spread-12",
+    "spread-16",
+    "spread-17",
+    "spread-19",
+    "spread-22",
+    "trap-13",
+    "trap-15",
+    "trap-22",
+    "trap-23",
+    "trap-24",
+    "trap-25",
+    "described-01",
+    "described-02",
+    "described-03",
+    "described-05",
+    "described-07",
+    "described-08",
+    "described-09",
+    "described-13",
+    "described-16",
+    "described-17",
+    "described-18",
+    "described-21",
+    "described-22",
+    "described-24"
+   ],
+   "per_query": {
+    "control_no_arm": {
+     "needle-02": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-07": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-09": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-10": {
+      "ndcg": 0.9502344167898356,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-11": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-05": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-04": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-05": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-06": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-11": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-12": {
+      "ndcg": 0.45560514958746035,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-16": {
+      "ndcg": 0.4796249331362629,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-17": {
+      "ndcg": 0.20151514190050246,
+      "doc_ndcg": 0.9638614719361266,
+      "dochit3": 1
+     },
+     "spread-19": {
+      "ndcg": 0.38009376671593426,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-22": {
+      "ndcg": 0.6131471927654584,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-13": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-15": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-24": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-01": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-02": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-03": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-05": {
+      "ndcg": 0.2890648263178879,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-08": {
+      "ndcg": 0.3562071871080222,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-09": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-13": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.38685280723454163,
+      "dochit3": 0
+     },
+     "described-16": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 0
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.0,
+      "dochit3": 0
+     },
+     "described-18": {
+      "ndcg": 0.2890648263178879,
+      "doc_ndcg": 0.5,
+      "dochit3": 0
+     },
+     "described-21": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 0
+     },
+     "described-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-24": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 0
+     }
+    },
+    "shipped_arm_w0.25": {
+     "needle-02": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-07": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-09": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-10": {
+      "ndcg": 0.9502344167898356,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-11": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-05": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.8175295903539445,
+      "dochit3": 1
+     },
+     "trap-04": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-05": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-06": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.38685280723454163,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-11": {
+      "ndcg": 0.5,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-12": {
+      "ndcg": 0.45560514958746035,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-16": {
+      "ndcg": 0.4796249331362629,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-17": {
+      "ndcg": 0.2129292954931993,
+      "doc_ndcg": 0.7224242270408039,
+      "dochit3": 1
+     },
+     "spread-19": {
+      "ndcg": 0.3273949503887395,
+      "doc_ndcg": 0.4796249331362629,
+      "dochit3": 1
+     },
+     "spread-22": {
+      "ndcg": 0.6131471927654584,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-13": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-15": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-24": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-01": {
+      "ndcg": 0.3333333333333333,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-02": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-03": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-05": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-08": {
+      "ndcg": 0.2890648263178879,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-09": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-13": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.38685280723454163,
+      "dochit3": 0
+     },
+     "described-16": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.3562071871080222,
+      "dochit3": 0
+     },
+     "described-18": {
+      "ndcg": 0.5,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     },
+     "described-21": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-24": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     }
+    }
+   },
+   "flips": {
+    "gained": [
+     "described-16",
+     "described-18",
+     "described-21",
+     "described-24"
+    ],
+    "lost": []
+   },
+   "table": {
+    "control_no_arm": {
+     "described": {
+      "ndcg": 0.1832,
+      "doc_ndcg": 0.6985,
+      "dochit3": 0.5714,
+      "n": 14
+     },
+     "needle": {
+      "ndcg": 0.9084,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "spread": {
+      "ndcg": 0.355,
+      "doc_ndcg": 0.914,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "trap": {
+      "ndcg": 0.8238,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 11
+     }
+    },
+    "shipped_arm_w0.25": {
+     "described": {
+      "ndcg": 0.1516,
+      "doc_ndcg": 0.724,
+      "dochit3": 0.8571,
+      "n": 14
+     },
+     "needle": {
+      "ndcg": 0.9084,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "spread": {
+      "ndcg": 0.3481,
+      "doc_ndcg": 0.7966,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "trap": {
+      "ndcg": 0.8016,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 11
+     }
+    }
+   }
+  },
+  "20260830": {
+   "n_eligible": 36,
+   "eligible_ids": [
+    "needle-01",
+    "needle-05",
+    "needle-12",
+    "needle-13",
+    "needle-14",
+    "spread-04",
+    "trap-01",
+    "trap-03",
+    "trap-06",
+    "trap-07",
+    "trap-08",
+    "spread-12",
+    "spread-18",
+    "spread-20",
+    "spread-23",
+    "spread-24",
+    "spread-25",
+    "trap-14",
+    "trap-17",
+    "trap-21",
+    "trap-22",
+    "trap-25",
+    "described-01",
+    "described-06",
+    "described-07",
+    "described-08",
+    "described-10",
+    "described-11",
+    "described-12",
+    "described-14",
+    "described-16",
+    "described-17",
+    "described-18",
+    "described-19",
+    "described-20",
+    "described-23"
+   ],
+   "per_query": {
+    "control_no_arm": {
+     "needle-01": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-12": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-13": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-14": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-04": {
+      "ndcg": 0.23719771276929622,
+      "doc_ndcg": 0.6131471927654584,
+      "dochit3": 1
+     },
+     "trap-01": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-03": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-06": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-08": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-12": {
+      "ndcg": 0.45560514958746035,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-18": {
+      "ndcg": 0.6916951540553927,
+      "doc_ndcg": 0.7606220037494031,
+      "dochit3": 1
+     },
+     "spread-20": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-23": {
+      "ndcg": 0.3175786993670768,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-24": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-25": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "trap-14": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-17": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-21": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-01": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-06": {
+      "ndcg": 0.2890648263178879,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 0
+     },
+     "described-08": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-10": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 0
+     },
+     "described-11": {
+      "ndcg": 0.38685280723454163,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-12": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-14": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-16": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.3562071871080222,
+      "dochit3": 0
+     },
+     "described-18": {
+      "ndcg": 0.3333333333333333,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 0
+     },
+     "described-19": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.0,
+      "dochit3": 0
+     },
+     "described-20": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     }
+    },
+    "shipped_arm_w0.25": {
+     "needle-01": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-12": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-13": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-14": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-04": {
+      "ndcg": 0.23719771276929622,
+      "doc_ndcg": 0.8772153153380493,
+      "dochit3": 1
+     },
+     "trap-01": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-03": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "trap-06": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-08": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-12": {
+      "ndcg": 0.45560514958746035,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-18": {
+      "ndcg": 0.5316519652587917,
+      "doc_ndcg": 0.7606220037494031,
+      "dochit3": 1
+     },
+     "spread-20": {
+      "ndcg": 0.4796249331362629,
+      "doc_ndcg": 0.9238850086262381,
+      "dochit3": 1
+     },
+     "spread-23": {
+      "ndcg": 0.39668756020386675,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-24": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.9502344167898356,
+      "dochit3": 1
+     },
+     "spread-25": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "trap-14": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-17": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-21": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-22": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-01": {
+      "ndcg": 0.3333333333333333,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-06": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     },
+     "described-08": {
+      "ndcg": 0.31546487678572877,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-10": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-11": {
+      "ndcg": 0.3333333333333333,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-12": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-14": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-16": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 1
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.38685280723454163,
+      "dochit3": 0
+     },
+     "described-18": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-19": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.43067655807339306,
+      "dochit3": 0
+     },
+     "described-20": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     }
+    }
+   },
+   "flips": {
+    "gained": [
+     "described-07",
+     "described-10",
+     "described-18"
+    ],
+    "lost": []
+   },
+   "table": {
+    "control_no_arm": {
+     "described": {
+      "ndcg": 0.3622,
+      "doc_ndcg": 0.7584,
+      "dochit3": 0.6429,
+      "n": 14
+     },
+     "needle": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 5
+     },
+     "spread": {
+      "ndcg": 0.5689,
+      "doc_ndcg": 0.8078,
+      "dochit3": 1.0,
+      "n": 7
+     },
+     "trap": {
+      "ndcg": 0.8323,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 10
+     }
+    },
+    "shipped_arm_w0.25": {
+     "described": {
+      "ndcg": 0.3295,
+      "doc_ndcg": 0.7914,
+      "dochit3": 0.8571,
+      "n": 14
+     },
+     "needle": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 5
+     },
+     "spread": {
+      "ndcg": 0.5173,
+      "doc_ndcg": 0.896,
+      "dochit3": 1.0,
+      "n": 7
+     },
+     "trap": {
+      "ndcg": 0.7385,
+      "doc_ndcg": 0.9631,
+      "dochit3": 1.0,
+      "n": 10
+     }
+    }
+   }
+  },
+  "20260831": {
+   "n_eligible": 32,
+   "eligible_ids": [
+    "needle-01",
+    "needle-03",
+    "needle-04",
+    "needle-05",
+    "needle-06",
+    "needle-08",
+    "spread-04",
+    "spread-07",
+    "spread-08",
+    "trap-02",
+    "trap-03",
+    "trap-07",
+    "trap-08",
+    "trap-10",
+    "trap-12",
+    "spread-15",
+    "spread-16",
+    "spread-24",
+    "trap-15",
+    "trap-16",
+    "trap-17",
+    "trap-20",
+    "trap-24",
+    "trap-25",
+    "described-07",
+    "described-09",
+    "described-11",
+    "described-13",
+    "described-17",
+    "described-20",
+    "described-21",
+    "described-23"
+   ],
+   "per_query": {
+    "control_no_arm": {
+     "needle-01": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-03": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-04": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-06": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-08": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-04": {
+      "ndcg": 0.23719771276929622,
+      "doc_ndcg": 0.6131471927654584,
+      "dochit3": 1
+     },
+     "spread-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6131471927654584,
+      "dochit3": 1
+     },
+     "spread-08": {
+      "ndcg": 0.3065735963827292,
+      "doc_ndcg": 0.3065735963827292,
+      "dochit3": 1
+     },
+     "trap-02": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-03": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-08": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-10": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-12": {
+      "ndcg": 0.3562071871080222,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-15": {
+      "ndcg": 0.39668756020386675,
+      "doc_ndcg": 0.7974779478881874,
+      "dochit3": 1
+     },
+     "spread-16": {
+      "ndcg": 0.4796249331362629,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-24": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "trap-15": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-16": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-17": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-20": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-24": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-09": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-11": {
+      "ndcg": 0.38685280723454163,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-13": {
+      "ndcg": 0.31546487678572877,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 0
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.5,
+      "dochit3": 0
+     },
+     "described-20": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-21": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     }
+    },
+    "shipped_arm_w0.25": {
+     "needle-01": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-03": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-04": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-05": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-06": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "needle-08": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-04": {
+      "ndcg": 0.23719771276929622,
+      "doc_ndcg": 0.9197207891481876,
+      "dochit3": 1
+     },
+     "spread-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6131471927654584,
+      "dochit3": 1
+     },
+     "spread-08": {
+      "ndcg": 0.21840743681816419,
+      "doc_ndcg": 0.21840743681816419,
+      "dochit3": 0
+     },
+     "trap-02": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-03": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-07": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-08": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-10": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-12": {
+      "ndcg": 0.31546487678572877,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "spread-15": {
+      "ndcg": 0.3430601340643824,
+      "doc_ndcg": 0.8935349950641011,
+      "dochit3": 1
+     },
+     "spread-16": {
+      "ndcg": 0.4796249331362629,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "spread-24": {
+      "ndcg": 0.7601875334318685,
+      "doc_ndcg": 0.7601875334318685,
+      "dochit3": 1
+     },
+     "trap-15": {
+      "ndcg": 0.43067655807339306,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-16": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-17": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-20": {
+      "ndcg": 0.6309297535714575,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-24": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "trap-25": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-07": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-09": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-11": {
+      "ndcg": 0.3562071871080222,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-13": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-17": {
+      "ndcg": 0.0,
+      "doc_ndcg": 0.6309297535714575,
+      "dochit3": 1
+     },
+     "described-20": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-21": {
+      "ndcg": 0.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     },
+     "described-23": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1
+     }
+    }
+   },
+   "flips": {
+    "gained": [
+     "described-13",
+     "described-17"
+    ],
+    "lost": [
+     "spread-08"
+    ]
+   },
+   "table": {
+    "control_no_arm": {
+     "described": {
+      "ndcg": 0.3378,
+      "doc_ndcg": 0.7991,
+      "dochit3": 0.75,
+      "n": 8
+     },
+     "needle": {
+      "ndcg": 1.0,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "spread": {
+      "ndcg": 0.3634,
+      "doc_ndcg": 0.6418,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "trap": {
+      "ndcg": 0.7592,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 12
+     }
+    },
+    "shipped_arm_w0.25": {
+     "described": {
+      "ndcg": 0.2945,
+      "doc_ndcg": 0.8155,
+      "dochit3": 1.0,
+      "n": 8
+     },
+     "needle": {
+      "ndcg": 0.9385,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 6
+     },
+     "spread": {
+      "ndcg": 0.3397,
+      "doc_ndcg": 0.6942,
+      "dochit3": 0.8333,
+      "n": 6
+     },
+     "trap": {
+      "ndcg": 0.6776,
+      "doc_ndcg": 1.0,
+      "dochit3": 1.0,
+      "n": 12
+     }
+    }
+   }
+  }
  }
 }

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.json
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.json
@@ -1,0 +1,5854 @@
+{
+ "100": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.5308,
+     "doc_ndcg": 0.846,
+     "dochit3": 0.8764,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.2282,
+     "doc_ndcg": 0.7299,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.3513,
+     "doc_ndcg": 0.7218,
+     "dochit3": 0.92,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7721,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4901,
+     "doc_ndcg": 0.8442,
+     "dochit3": 0.8876,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.2142,
+     "doc_ndcg": 0.7548,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.291,
+     "doc_ndcg": 0.6904,
+     "dochit3": 0.88,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7164,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.23463936301137822,
+     "doc_ndcg": 0.7039180890341347,
+     "dochit3": 1
+    },
+    "spread-03": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.5316519652587917,
+     "dochit3": 1
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5706417189553201,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.3065735963827292,
+     "doc_ndcg": 0.3065735963827292,
+     "dochit3": 1
+    },
+    "spread-09": {
+     "ndcg": 0.2920782154400332,
+     "doc_ndcg": 0.49818925746641285,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.16004318879660112,
+     "doc_ndcg": 0.16771752171325524,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.10283552761606227,
+     "doc_ndcg": 0.9651954696014428,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.45560514958746035,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9699225363013644,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9674679834891693,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.2129292954931993,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.6993694869720469,
+     "doc_ndcg": 0.888747738037333,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.10987173866025332,
+     "doc_ndcg": 0.9238850086262381,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.6131471927654584,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.3175786993670768,
+     "doc_ndcg": 0.6461369845040973,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.46927872602275644,
+     "dochit3": 1
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.8503449055347546,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6052602440527057,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3065735963827292,
+     "dochit3": 1
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.19342640361727081,
+     "doc_ndcg": 0.19342640361727081,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 0.4632423659320675,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.15368188299909635,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.10283552761606227,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.45560514958746035,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.18937825106528608,
+     "doc_ndcg": 0.8935349950641011,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.2275408362015762,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.685333848257888,
+     "doc_ndcg": 0.8518080397362219,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.626665273802673,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.9072278740982787,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.6131471927654584,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.4683480347412084,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.9502344167898356,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-21",
+    "spread-06"
+   ],
+   "lost": [
+    "spread-03",
+    "spread-08"
+   ]
+  }
+ },
+ "150": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.5113,
+     "doc_ndcg": 0.8136,
+     "dochit3": 0.8539,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.2135,
+     "doc_ndcg": 0.678,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2966,
+     "doc_ndcg": 0.6584,
+     "dochit3": 0.84,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7721,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4792,
+     "doc_ndcg": 0.8253,
+     "dochit3": 0.8764,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1958,
+     "doc_ndcg": 0.7114,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2729,
+     "doc_ndcg": 0.6667,
+     "dochit3": 0.84,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.714,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.15642624200758548,
+     "doc_ndcg": 0.6364391809889587,
+     "dochit3": 1
+    },
+    "spread-03": {
+     "ndcg": 0.20567105523212453,
+     "doc_ndcg": 0.20567105523212453,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5706417189553201,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.3084274278260313,
+     "doc_ndcg": 0.49818925746641285,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9651954696014428,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.5012658353418871,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9556956695617674,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.15642624200758548,
+     "doc_ndcg": 0.8854598815714874,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.2129292954931993,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.8765868087249774,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.10987173866025332,
+     "doc_ndcg": 0.9072278740982787,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 0.6934264036172708,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.36051510816203886,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3010299956639812,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.46927872602275644,
+     "dochit3": 1
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.8503449055347546,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6052602440527057,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.23719771276929622,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.1480409554829326,
+     "doc_ndcg": 0.4632423659320675,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.5012658353418871,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9060254355346823,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.20567105523212453,
+     "doc_ndcg": 0.9003134755042497,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.2275408362015762,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.888747738037333,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.626665273802673,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8868854556705132,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.6131471927654584,
+     "doc_ndcg": 0.9197207891481876,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.4683480347412084,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.9238850086262381,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.31546487678572877,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 0.31546487678572877,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-21"
+   ],
+   "lost": []
+  }
+ },
+ "200": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.5038,
+     "doc_ndcg": 0.7879,
+     "dochit3": 0.8427,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1987,
+     "doc_ndcg": 0.6632,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2845,
+     "doc_ndcg": 0.5817,
+     "dochit3": 0.8,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7721,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4716,
+     "doc_ndcg": 0.7992,
+     "dochit3": 0.8427,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1685,
+     "doc_ndcg": 0.6436,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2758,
+     "doc_ndcg": 0.6417,
+     "dochit3": 0.8,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7113,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.17721732175293053,
+     "doc_ndcg": 0.17721732175293053,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5706417189553201,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3065735963827292,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.3084274278260313,
+     "doc_ndcg": 0.49818925746641285,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9651954696014428,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.46845052016107697,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8860866087646527,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9325210919548239,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.2275408362015762,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.6993694869720469,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.4796249331362629,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.34968474348602346,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3010299956639812,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.8503449055347546,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6052602440527057,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.21840743681816419,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3065735963827292,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 0.4525081529734507,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.44130740935663865,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.13565197343244778,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.18937825106528608,
+     "doc_ndcg": 0.8634575313654654,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.24711688711205218,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8955796649110442,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8955796649110442,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.6131471927654584,
+     "doc_ndcg": 0.8175295903539445,
+     "dochit3": 1
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.4683480347412084,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8955796649110442,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-21"
+   ],
+   "lost": [
+    "described-02",
+    "described-12"
+   ]
+  }
+ },
+ "300": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.4908,
+     "doc_ndcg": 0.7727,
+     "dochit3": 0.7978,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1679,
+     "doc_ndcg": 0.6352,
+     "dochit3": 0.56,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.272,
+     "doc_ndcg": 0.5558,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7693,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4631,
+     "doc_ndcg": 0.7754,
+     "dochit3": 0.8202,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1447,
+     "doc_ndcg": 0.6067,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2647,
+     "doc_ndcg": 0.5938,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.716,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.15368188299909635,
+     "doc_ndcg": 0.18937825106528608,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5706417189553201,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.23719771276929622,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.3084274278260313,
+     "doc_ndcg": 0.49818925746641285,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8069320812880308,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.5249810332008933,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9325210919548239,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.24711688711205218,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.605988092755828,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.4796249331362629,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.21840743681816419,
+     "doc_ndcg": 0.21840743681816419,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.26582598262939583,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3010299956639812,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6052602440527057,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.20438239758848611,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 0.4525081529734507,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9651954696014428,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.48381288316677695,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.13565197343244778,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.18937825106528608,
+     "doc_ndcg": 0.8634575313654654,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.27511096828801057,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.7210302163240777,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8868854556705132,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.2640681225725909,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.4499200626718163,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8868854556705132,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.2890648263178879,
+     "dochit3": 0
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.5,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.5,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-14",
+    "described-21",
+    "described-23"
+   ],
+   "lost": [
+    "described-02",
+    "described-12"
+   ]
+  }
+ },
+ "400": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.4833,
+     "doc_ndcg": 0.7572,
+     "dochit3": 0.7753,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1662,
+     "doc_ndcg": 0.615,
+     "dochit3": 0.52,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2602,
+     "doc_ndcg": 0.5208,
+     "dochit3": 0.68,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7561,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4501,
+     "doc_ndcg": 0.7695,
+     "dochit3": 0.8315,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1499,
+     "doc_ndcg": 0.6072,
+     "dochit3": 0.68,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.265,
+     "doc_ndcg": 0.5722,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.6643,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5437713091520254,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.23719771276929622,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.4776237035032179,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.33858404654682245,
+     "dochit3": 0
+    },
+    "spread-12": {
+     "ndcg": 0.5249810332008933,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9325210919548239,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.24711688711205218,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.36866151024545807,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.4796249331362629,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.21840743681816419,
+     "doc_ndcg": 0.21840743681816419,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.3354350434265105,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5912352048230277,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.18457569677956817,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 0.4525081529734507,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6012610260559063,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.4911492931622974,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.13565197343244778,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.18937825106528608,
+     "doc_ndcg": 0.8634575313654654,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.27511096828801057,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.512652365179441,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.2640681225725909,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.6344874928748538,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8955796649110442,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.5,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-09",
+    "described-14",
+    "described-21",
+    "described-23",
+    "spread-11"
+   ],
+   "lost": [
+    "described-12"
+   ]
+  }
+ },
+ "500": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.4799,
+     "doc_ndcg": 0.7481,
+     "dochit3": 0.7528,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1569,
+     "doc_ndcg": 0.6097,
+     "dochit3": 0.48,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2599,
+     "doc_ndcg": 0.5084,
+     "dochit3": 0.64,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7537,
+     "doc_ndcg": 0.9852,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4539,
+     "doc_ndcg": 0.7514,
+     "dochit3": 0.8315,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1461,
+     "doc_ndcg": 0.5872,
+     "dochit3": 0.68,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2701,
+     "doc_ndcg": 0.5427,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.6764,
+     "doc_ndcg": 0.9852,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5437713091520254,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.23719771276929622,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.4776237035032179,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.33858404654682245,
+     "dochit3": 0
+    },
+    "spread-12": {
+     "ndcg": 0.5249810332008933,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5316519652587917,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9325210919548239,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.27511096828801057,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.2289700384906115,
+     "doc_ndcg": 0.32365916402325456,
+     "dochit3": 0
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.4796249331362629,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.21840743681816419,
+     "doc_ndcg": 0.21840743681816419,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.3354350434265105,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5912352048230277,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.23719771276929622,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.14126697285982898,
+     "doc_ndcg": 0.4525081529734507,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.3333333333333333,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6107608260955816,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.4911492931622974,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5316519652587917,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.13565197343244778,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8634575313654654,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.31939394323979897,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.26582598262939583,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.2640681225725909,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.5316519652587917,
+     "doc_ndcg": 0.6263410907914347,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8800937667159342,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3562071871080222,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.5,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-09",
+    "described-14",
+    "described-20",
+    "described-21",
+    "described-23",
+    "spread-11",
+    "spread-18"
+   ],
+   "lost": [
+    "described-12"
+   ]
+  }
+ }
+}

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.json
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.json
@@ -5850,5 +5850,982 @@
     "described-12"
    ]
   }
+ },
+ "350": {
+  "table": {
+   "control_no_arm": {
+    "overall": {
+     "ndcg": 0.4869,
+     "doc_ndcg": 0.7652,
+     "dochit3": 0.7865,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1679,
+     "doc_ndcg": 0.6179,
+     "dochit3": 0.52,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9607,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2631,
+     "doc_ndcg": 0.5462,
+     "dochit3": 0.72,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.7642,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   },
+   "shipped_arm_w0.25": {
+    "overall": {
+     "ndcg": 0.4547,
+     "doc_ndcg": 0.7757,
+     "dochit3": 0.8427,
+     "n": 89
+    },
+    "described": {
+     "ndcg": 0.1499,
+     "doc_ndcg": 0.6147,
+     "dochit3": 0.68,
+     "n": 25
+    },
+    "needle": {
+     "ndcg": 0.9344,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 14
+    },
+    "spread": {
+     "ndcg": 0.2574,
+     "doc_ndcg": 0.5867,
+     "dochit3": 0.76,
+     "n": 25
+    },
+    "trap": {
+     "ndcg": 0.6883,
+     "doc_ndcg": 1.0,
+     "dochit3": 1.0,
+     "n": 25
+    }
+   }
+  },
+  "per_query": {
+   "control_no_arm": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.2662191925648343,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5706417189553201,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.3084274278260313,
+     "doc_ndcg": 0.49818925746641285,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.3562071871080222,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8069320812880308,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.5249810332008933,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.16716045496620227,
+     "doc_ndcg": 0.9325210919548239,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.39668756020386675,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.24711688711205218,
+     "doc_ndcg": 0.8403030283801005,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.5287046990420592,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.4796249331362629,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.21840743681816419,
+     "doc_ndcg": 0.21840743681816419,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.26582598262939583,
+     "doc_ndcg": 0.26582598262939583,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-08": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 0
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   },
+   "shipped_arm_w0.25": {
+    "needle-01": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-02": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-05": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-06": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-07": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-08": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-09": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-10": {
+     "ndcg": 0.9502344167898356,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-12": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "needle-14": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-01": {
+     "ndcg": 0.3430601340643824,
+     "doc_ndcg": 0.8670870086853021,
+     "dochit3": 1
+    },
+    "spread-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-04": {
+     "ndcg": 0.23719771276929622,
+     "doc_ndcg": 0.6131471927654584,
+     "dochit3": 1
+    },
+    "spread-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6052602440527057,
+     "dochit3": 1
+    },
+    "spread-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.19342640361727081,
+     "dochit3": 0
+    },
+    "spread-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.3065735963827292,
+     "dochit3": 1
+    },
+    "spread-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "spread-09": {
+     "ndcg": 0.1480409554829326,
+     "doc_ndcg": 0.4632423659320675,
+     "dochit3": 1
+    },
+    "spread-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "trap-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-02": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-03": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-04": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-05": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-06": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-07": {
+     "ndcg": 0.38685280723454163,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-08": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-09": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-10": {
+     "ndcg": 0.43067655807339306,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-11": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-12": {
+     "ndcg": 0.2890648263178879,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-11": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.9651954696014428,
+     "dochit3": 1
+    },
+    "spread-12": {
+     "ndcg": 0.4911492931622974,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.7974779478881874,
+     "dochit3": 1
+    },
+    "spread-14": {
+     "ndcg": 0.13565197343244778,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-15": {
+     "ndcg": 0.18937825106528608,
+     "doc_ndcg": 0.8634575313654654,
+     "dochit3": 1
+    },
+    "spread-16": {
+     "ndcg": 0.4796249331362629,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-17": {
+     "ndcg": 0.27511096828801057,
+     "doc_ndcg": 0.7224242270408039,
+     "dochit3": 1
+    },
+    "spread-18": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.5248132944917966,
+     "dochit3": 1
+    },
+    "spread-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.8746071583782724,
+     "dochit3": 1
+    },
+    "spread-20": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "spread-21": {
+     "ndcg": 0.9197207891481876,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "spread-22": {
+     "ndcg": 0.2640681225725909,
+     "doc_ndcg": 0.2640681225725909,
+     "dochit3": 0
+    },
+    "spread-23": {
+     "ndcg": 0.3354350434265105,
+     "doc_ndcg": 0.4382705710425728,
+     "dochit3": 1
+    },
+    "spread-24": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.8868854556705132,
+     "dochit3": 1
+    },
+    "spread-25": {
+     "ndcg": 0.7601875334318685,
+     "doc_ndcg": 0.7601875334318685,
+     "dochit3": 1
+    },
+    "trap-13": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-14": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-15": {
+     "ndcg": 0.5,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-16": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-17": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-18": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-19": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-20": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-21": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-23": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-24": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "trap-25": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-01": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-02": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-03": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-04": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-05": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-06": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-07": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-08": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-09": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-10": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-11": {
+     "ndcg": 0.3010299956639812,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-12": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.2890648263178879,
+     "dochit3": 0
+    },
+    "described-13": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-14": {
+     "ndcg": 0.6309297535714575,
+     "doc_ndcg": 0.6309297535714575,
+     "dochit3": 1
+    },
+    "described-15": {
+     "ndcg": 0.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-16": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.38685280723454163,
+     "dochit3": 0
+    },
+    "described-17": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-18": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-19": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.0,
+     "dochit3": 0
+    },
+    "described-20": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-21": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-22": {
+     "ndcg": 1.0,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    },
+    "described-23": {
+     "ndcg": 0.5,
+     "doc_ndcg": 0.5,
+     "dochit3": 1
+    },
+    "described-24": {
+     "ndcg": 0.0,
+     "doc_ndcg": 0.43067655807339306,
+     "dochit3": 0
+    },
+    "described-25": {
+     "ndcg": 0.31546487678572877,
+     "doc_ndcg": 1.0,
+     "dochit3": 1
+    }
+   }
+  },
+  "flips": {
+   "gained": [
+    "described-07",
+    "described-09",
+    "described-14",
+    "described-21",
+    "described-23",
+    "spread-07"
+   ],
+   "lost": [
+    "described-12"
+   ]
+  }
  }
 }

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.md
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.md
@@ -135,38 +135,49 @@ a persistent two-query tax.
 **Described gain first exceeds one query at size 100**, the smallest
 corpus tested: 2 net gains (described-07, described-21) with zero losses.
 The gain is present at every size in the sweep, ranging +2 (100, 150,
-300) to +5 (500), and never negative.
+300) to +5 (350, 500), and never negative.
 
 **The spread loss is not the same two queries at every size.** spread-03
 and spread-08 are lost to the arm only at size 100; from 150 onward
 control already misses both regardless of the arm (buried by
 distractors), so there is no incremental arm-caused loss on them past
-100. From 400 onward the arm nets a spread gain instead (spread-11 at
-400, plus spread-18 at 500), so the net spread effect flips sign across
-the sweep: -1 query at 100, 0 at 150-300, +1 at 400, +2 at 500.
+100. From 350 onward the arm nets a spread gain instead: spread-07 at
+350, spread-11 at 400, spread-11 and spread-18 at 500. These are three
+different queries across three sizes, not one query recurring, so the
+net spread effect flips sign across the sweep and keeps changing which
+query it is made of: -1 query at 100, 0 at 150-300, +1 at 350 and 400
+(different query each time), +2 at 500.
 
 **Needle never moves.** Doc-hit@3 and doc-NDCG are 1.00/1.000 for both
-rows at every size; the arm has zero measurable effect on this class
-anywhere in the sweep.
+rows at every size, including 350; the arm has zero measurable effect on
+this class anywhere in the sweep.
 
 **Trap moves only with corpus size, never with the arm.** hit@3 stays
-1.00 throughout. dNDCG stays 1.000 for both rows through size 400 and
-drops to 0.985 for both rows at size 500, identically, meaning the drop
-comes from distractor dilution at 500 docs, not from the doc-profile arm
-(control and shipped are equal at every size).
+1.00 throughout. dNDCG stays 1.000 for both rows through size 400
+(350 included) and drops to 0.985 for both rows at size 500, identically,
+meaning the drop comes from distractor dilution at 500 docs, not from the
+doc-profile arm (control and shipped are equal at every size).
 
-**Neither curve is cleanly monotone.** Control described h@3 is
-non-increasing (0.64, 0.64, 0.64, 0.56, 0.52, 0.48) but shipped described
-h@3 is not: 0.72, 0.72, 0.64, 0.72, 0.68, 0.68, so from a pure hit@3 point
-of view it dips into a rest a hit-count away from its own value at 200. Once
-converted to a query count out of 25 this is 18, 18, 16, 16, 17, 17. Spread
-h@3 is non-increasing for control (0.92 down to 0.64) and for shipped
-(0.88 down to, then flat at, 0.72 from 300 on). doc-NDCG for both classes
-is not monotone at all: e.g. shipped spread dNDCG rises from 0.690 (100)
-to 0.667 (150) to 0.642 (200) then falls back toward 0.543 (500),
-non-monotone in both directions across the sweep. Described dNDCG for
-control falls 0.730 -> 0.678 -> 0.663 -> 0.635 -> 0.615 -> 0.610
-(monotone decreasing); shipped described dNDCG is roughly flat to
-declining (0.755, 0.711, 0.644, 0.607, 0.607, 0.587) with one local
-recovery pattern in the middle (0.644 at 200 close to the 300 value) but
-overall non-increasing across the six points.
+**Hit@3 curves are not cleanly monotone; doc-NDCG curves mostly are, once
+350 is in.** Control described h@3 is non-increasing across all seven
+points (0.64, 0.64, 0.64, 0.56, 0.52, 0.52, 0.48 at 100/150/200/300/350/
+400/500). Shipped described h@3 is not: 0.72, 0.72, 0.64, 0.64, 0.68,
+0.68, 0.68, a dip to 16/25 queries at 200-300 followed by a rise to 17/25
+that holds from 350 through 500. Control spread h@3 is non-increasing
+(0.92 down to 0.64, flat at 300-350). Shipped spread h@3 is not: 0.88,
+0.84, 0.80, 0.72, 0.76, 0.72, 0.72, a one-point bump at 350 (spread-07,
+the query that is gained only at that size) sitting between two 0.72
+plateaus.
+
+Doc-NDCG is cleaner: both spread curves (control 0.722, 0.658, 0.582,
+0.556, 0.546, 0.521, 0.508; shipped 0.690, 0.667, 0.642, 0.594, 0.587,
+0.572, 0.543) are monotone decreasing across all seven sizes, including
+350, correcting an earlier read of this data before 350 was added that
+called the shipped spread dNDCG curve non-monotone. Control described
+dNDCG is also monotone decreasing (0.730, 0.678, 0.663, 0.635, 0.618,
+0.615, 0.610). Shipped described dNDCG is the one doc-NDCG series that is
+not monotone: 0.755, 0.711, 0.644, 0.607, 0.615, 0.607, 0.587, a small
+bump at 350 (0.607 -> 0.615) before falling back to 0.607 at 400. So the
+only two non-monotone series in the sweep, shipped described h@3 and
+shipped spread h@3, are both hit@3 metrics on the shipped row, and 350 is
+where the spread one shows its bump.

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.md
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.md
@@ -25,11 +25,12 @@ the arm starts paying or whether the one-query spread loss at 100 recurs.
   0.64 to 0.72 across the range and spread stops decaying past 300.
 - The spread loss exists only at 100 (spread-03, spread-08). From 150 up
   the control already misses both, so the arm never costs a spread query
-  there and starts paying at 400.
+  there and starts paying at 350 (+1) and 400 (+1), +2 at 500.
 - Needle never moves. Trap is identical in both rows at every size (the
   0.985 at 500 is a corpus effect, present with and without the arm).
-- Not perfectly monotone (described delta 0 at 200): n=25, one query is 4
-  points; read the trend, not single cells.
+- Described gain by size: +2, +2, 0, +2, +4, +4, +5 queries at 100, 150,
+  200, 300, 350, 400, 500. Not perfectly monotone (0 at 200): n=25, one
+  query is 4 points; read the trend, not single cells.
 
 ## Fidelity check
 
@@ -52,6 +53,7 @@ Both match. Full numbers in `sweep.json`.
 | 150 | 0.64 | 0.72 | +2 | 0.678 | 0.711 |
 | 200 | 0.64 | 0.64 | 0 | 0.663 | 0.644 |
 | 300 | 0.56 | 0.64 | +2 | 0.635 | 0.607 |
+| 350 | 0.52 | 0.68 | +4 | 0.618 | 0.615 |
 | 400 | 0.52 | 0.68 | +4 | 0.615 | 0.607 |
 | 500 | 0.48 | 0.68 | +5 | 0.610 | 0.587 |
 
@@ -63,6 +65,7 @@ Both match. Full numbers in `sweep.json`.
 | 150 | 0.84 | 0.84 | 0 | 0.658 | 0.667 |
 | 200 | 0.80 | 0.80 | 0 | 0.582 | 0.642 |
 | 300 | 0.72 | 0.72 | 0 | 0.556 | 0.594 |
+| 350 | 0.72 | 0.76 | +1 | 0.546 | 0.587 |
 | 400 | 0.68 | 0.72 | +1 | 0.521 | 0.572 |
 | 500 | 0.64 | 0.72 | +2 | 0.508 | 0.543 |
 
@@ -74,6 +77,7 @@ Both match. Full numbers in `sweep.json`.
 | 150 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 200 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 300 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 350 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 400 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 500 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 
@@ -85,6 +89,7 @@ Both match. Full numbers in `sweep.json`.
 | 150 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 200 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 300 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 350 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 400 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
 | 500 | 1.00 | 1.00 | 0 | 0.985 | 0.985 |
 
@@ -96,6 +101,7 @@ Both match. Full numbers in `sweep.json`.
 | 150 | described-07, described-21 | (none) | (none) | (none) |
 | 200 | described-07, described-21 | described-02, described-12 | (none) | (none) |
 | 300 | described-07, described-14, described-21, described-23 | described-02, described-12 | (none) | (none) |
+| 350 | described-07, described-09, described-14, described-21, described-23 | described-12 | spread-07 | (none) |
 | 400 | described-07, described-09, described-14, described-21, described-23 | described-12 | spread-11 | (none) |
 | 500 | described-07, described-09, described-14, described-20, described-21, described-23 | described-12 | spread-11, spread-18 | (none) |
 
@@ -113,6 +119,7 @@ re-weighting. The per-query trace shows a size effect underneath that:
 | 150 | 0 | 0 | 0 | 0 |
 | 200 | 0 | 0 | 0 | 0 |
 | 300 | 0 | 0 | 0 | 0 |
+| 350 | 0 | 0 | 0 | 0 |
 | 400 | 0 | 0 | 0 | 0 |
 | 500 | 0 | 0 | 0 | 0 |
 

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.md
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.md
@@ -28,6 +28,11 @@ the arm starts paying or whether the one-query spread loss at 100 recurs.
   there and starts paying at 350 (+1) and 400 (+1), +2 at 500.
 - Needle never moves. Trap is identical in both rows at every size (the
   0.985 at 500 is a corpus effect, present with and without the arm).
+- Below 100 (three 50-doc subsets of the gold docs, only fully covered
+  queries graded, n per class 6 to 14): described +4, +3, +2 queries with
+  no loss; spread flat in two subsets and -1 (spread-08 again) in the
+  third; needle flat; trap hit@3 flat. The arm helps described at every
+  size measured, and spread-08 is the one recurring casualty below 150.
 - Described gain by size: +2, +2, 0, +2, +4, +4, +5 queries at 100, 150,
   200, 300, 350, 400, 500. Not perfectly monotone (0 at 200): n=25, one
   query is 4 points; read the trend, not single cells.
@@ -107,6 +112,63 @@ Both match. Full numbers in `sweep.json`.
 
 needle and trap: no query flips hit@3 at any size (both classes hold
 1.00 h@3 identically for control and shipped at every size).
+
+## size 50 (gold subsets)
+
+Three fixed-seed 50-doc draws from the 100 gold docs (seeds 20260829,
+20260830, 20260831; deterministic shuffle of manifest order, first 50),
+run on cache100, no re-warming. A query is graded only when every one of
+its gold documents is inside the subset; a query with any gold doc
+missing from the subset is skipped entirely, so n varies per subset and
+per class and is smaller than the full 25/25/14/25 counts used at sizes
+100 and up.
+
+### seed 20260829 (37/89 queries eligible)
+
+| class | n | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|---|
+| described | 14 | 0.571 | 0.857 | +4 | 0.699 | 0.724 |
+| spread | 6 | 1.000 | 1.000 | 0 | 0.914 | 0.797 |
+| needle | 6 | 1.000 | 1.000 | 0 | 1.000 | 1.000 |
+| trap | 11 | 1.000 | 1.000 | 0 | 1.000 | 1.000 |
+
+Flipped: described gained described-16, described-18, described-21,
+described-24; nothing lost in any class.
+
+### seed 20260830 (36/89 queries eligible)
+
+| class | n | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|---|
+| described | 14 | 0.643 | 0.857 | +3 | 0.758 | 0.791 |
+| spread | 7 | 1.000 | 1.000 | 0 | 0.808 | 0.896 |
+| needle | 5 | 1.000 | 1.000 | 0 | 1.000 | 1.000 |
+| trap | 10 | 1.000 | 1.000 | 0 | 1.000 | 0.963 |
+
+Flipped: described gained described-07, described-10, described-18;
+nothing lost in any class.
+
+### seed 20260831 (32/89 queries eligible)
+
+| class | n | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|---|
+| described | 8 | 0.750 | 1.000 | +2 | 0.799 | 0.816 |
+| spread | 6 | 1.000 | 0.833 | -1 | 0.642 | 0.694 |
+| needle | 6 | 1.000 | 1.000 | 0 | 1.000 | 1.000 |
+| trap | 12 | 1.000 | 1.000 | 0 | 1.000 | 1.000 |
+
+Flipped: described gained described-13, described-17; spread lost
+spread-08, the same query the 100-doc corpus loses.
+
+### Reading
+
+The arm loses a query at 50 docs only in one of three subsets (seed
+20260831, spread-08, the same gold document the 100-doc corpus also
+loses to the arm); the other two seeds show described-only gains and no
+losses anywhere. Needle is flat (h@3 1.000, dNDCG 1.000) in all three
+subsets. Trap h@3 is flat at 1.000 in all three, but trap dNDCG dips for
+the shipped row at seed 20260830 (1.000 control vs 0.963 shipped, n=10)
+with no hit@3 change, so the arm reorders a trap result there without
+demoting the correct top pick.
 
 ## What spread-03 and spread-08 actually do across the sweep
 

--- a/benchmark_data/corpus_search/doc_arm_size_sweep.md
+++ b/benchmark_data/corpus_search/doc_arm_size_sweep.md
@@ -1,0 +1,165 @@
+# Document arm: corpus-size sweep (2026-08-29)
+
+Measured on branch `feat/doc-profile-routing` at 6c9700e, deterministic, no
+LLM judge. One warmed isolated cache (100 gold arXiv docs from
+`manifest.json` plus the 400 distractors from `distractor_manifest.json`,
+text, page embeddings, and doc profiles). Nested corpora: the 100 gold docs
+plus the first N of a fixed shuffle (seed 20260829) of the distractor
+manifest, N in 0, 50, 100, 200, 300, 400, giving sizes 100 to 500. All 89
+graded queries, two rows per size: `control_no_arm` (keyword + semantic
+page arms only, the pre-arm hybrid) and `shipped_arm_w0.25` (adds the
+document arm at `CORPUS_DOC_ARM_WEIGHT`). Arms are rebuilt from the server
+internals (`_corpus_keyword_rankings` with the term-coverage tie-break,
+`_corpus_semantic_scores`, `_corpus_doc_scores`, fused by
+`corpus.rrf_fuse_rankings_scored`), graded by the modes harness's own
+functions, top_k 10, ties by (doc_path, page). Raw numbers in
+`doc_arm_size_sweep.json`.
+
+Why this exists: the 100-doc and 500-doc gates alone could not show where
+the arm starts paying or whether the one-query spread loss at 100 recurs.
+
+## Reading
+
+- Without the arm retrieval decays with corpus size (described doc-hit@3
+  0.64 to 0.48, spread 0.92 to 0.64). With the arm, described holds at
+  0.64 to 0.72 across the range and spread stops decaying past 300.
+- The spread loss exists only at 100 (spread-03, spread-08). From 150 up
+  the control already misses both, so the arm never costs a spread query
+  there and starts paying at 400.
+- Needle never moves. Trap is identical in both rows at every size (the
+  0.985 at 500 is a corpus effect, present with and without the arm).
+- Not perfectly monotone (described delta 0 at 200): n=25, one query is 4
+  points; read the trend, not single cells.
+
+## Fidelity check
+
+Metadata verified non-None for all 500 docs before the sweep ran.
+Size-100 and size-500 rows reproduce the committed same-day numbers
+exactly:
+
+- 100: control described 0.64/0.730, spread 0.92/0.722; shipped
+  0.72/0.755, spread 0.88/0.690.
+- 500: control described 0.48, shipped 0.68, spread 0.64 -> 0.72, needle
+  doc-NDCG 1.000, trap doc-NDCG 0.985.
+
+Both match. Full numbers in `sweep.json`.
+
+## described (n=25)
+
+| size | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|
+| 100 | 0.64 | 0.72 | +2 | 0.730 | 0.755 |
+| 150 | 0.64 | 0.72 | +2 | 0.678 | 0.711 |
+| 200 | 0.64 | 0.64 | 0 | 0.663 | 0.644 |
+| 300 | 0.56 | 0.64 | +2 | 0.635 | 0.607 |
+| 400 | 0.52 | 0.68 | +4 | 0.615 | 0.607 |
+| 500 | 0.48 | 0.68 | +5 | 0.610 | 0.587 |
+
+## spread (n=25)
+
+| size | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|
+| 100 | 0.92 | 0.88 | -1 | 0.722 | 0.690 |
+| 150 | 0.84 | 0.84 | 0 | 0.658 | 0.667 |
+| 200 | 0.80 | 0.80 | 0 | 0.582 | 0.642 |
+| 300 | 0.72 | 0.72 | 0 | 0.556 | 0.594 |
+| 400 | 0.68 | 0.72 | +1 | 0.521 | 0.572 |
+| 500 | 0.64 | 0.72 | +2 | 0.508 | 0.543 |
+
+## needle (n=14)
+
+| size | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|
+| 100 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 150 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 200 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 300 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 400 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 500 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+
+## trap (n=25)
+
+| size | control h@3 | shipped h@3 | delta (queries) | control dNDCG | shipped dNDCG |
+|---|---|---|---|---|---|
+| 100 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 150 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 200 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 300 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 400 | 1.00 | 1.00 | 0 | 1.000 | 1.000 |
+| 500 | 1.00 | 1.00 | 0 | 0.985 | 0.985 |
+
+## Flips vs control, by size (hit@3 change only)
+
+| size | described gained | described lost | spread gained | spread lost |
+|---|---|---|---|---|
+| 100 | described-07, described-21 | (none) | spread-06 | spread-03, spread-08 |
+| 150 | described-07, described-21 | (none) | (none) | (none) |
+| 200 | described-07, described-21 | described-02, described-12 | (none) | (none) |
+| 300 | described-07, described-14, described-21, described-23 | described-02, described-12 | (none) | (none) |
+| 400 | described-07, described-09, described-14, described-21, described-23 | described-12 | spread-11 | (none) |
+| 500 | described-07, described-09, described-14, described-20, described-21, described-23 | described-12 | spread-11, spread-18 | (none) |
+
+needle and trap: no query flips hit@3 at any size (both classes hold
+1.00 h@3 identically for control and shipped at every size).
+
+## What spread-03 and spread-08 actually do across the sweep
+
+The 100-doc spike attributed the two spread losses to the arm's
+re-weighting. The per-query trace shows a size effect underneath that:
+
+| size | spread-03 control h@3 | spread-03 shipped h@3 | spread-08 control h@3 | spread-08 shipped h@3 |
+|---|---|---|---|---|
+| 100 | 1 | 0 | 1 | 0 |
+| 150 | 0 | 0 | 0 | 0 |
+| 200 | 0 | 0 | 0 | 0 |
+| 300 | 0 | 0 | 0 | 0 |
+| 400 | 0 | 0 | 0 | 0 |
+| 500 | 0 | 0 | 0 | 0 |
+
+At size 100 the arm is what costs these two queries: control still finds
+the gold document, shipped does not. From size 150 on, control itself no
+longer finds either gold document (distractors alone bury it before the
+arm is even applied), so both rows already read 0 and the arm has nothing
+left to lose on these two queries. This loss is a size-100 artifact, not
+a persistent two-query tax.
+
+## Reading
+
+**Described gain first exceeds one query at size 100**, the smallest
+corpus tested: 2 net gains (described-07, described-21) with zero losses.
+The gain is present at every size in the sweep, ranging +2 (100, 150,
+300) to +5 (500), and never negative.
+
+**The spread loss is not the same two queries at every size.** spread-03
+and spread-08 are lost to the arm only at size 100; from 150 onward
+control already misses both regardless of the arm (buried by
+distractors), so there is no incremental arm-caused loss on them past
+100. From 400 onward the arm nets a spread gain instead (spread-11 at
+400, plus spread-18 at 500), so the net spread effect flips sign across
+the sweep: -1 query at 100, 0 at 150-300, +1 at 400, +2 at 500.
+
+**Needle never moves.** Doc-hit@3 and doc-NDCG are 1.00/1.000 for both
+rows at every size; the arm has zero measurable effect on this class
+anywhere in the sweep.
+
+**Trap moves only with corpus size, never with the arm.** hit@3 stays
+1.00 throughout. dNDCG stays 1.000 for both rows through size 400 and
+drops to 0.985 for both rows at size 500, identically, meaning the drop
+comes from distractor dilution at 500 docs, not from the doc-profile arm
+(control and shipped are equal at every size).
+
+**Neither curve is cleanly monotone.** Control described h@3 is
+non-increasing (0.64, 0.64, 0.64, 0.56, 0.52, 0.48) but shipped described
+h@3 is not: 0.72, 0.72, 0.64, 0.72, 0.68, 0.68, so from a pure hit@3 point
+of view it dips into a rest a hit-count away from its own value at 200. Once
+converted to a query count out of 25 this is 18, 18, 16, 16, 17, 17. Spread
+h@3 is non-increasing for control (0.92 down to 0.64) and for shipped
+(0.88 down to, then flat at, 0.72 from 300 on). doc-NDCG for both classes
+is not monotone at all: e.g. shipped spread dNDCG rises from 0.690 (100)
+to 0.667 (150) to 0.642 (200) then falls back toward 0.543 (500),
+non-monotone in both directions across the sweep. Described dNDCG for
+control falls 0.730 -> 0.678 -> 0.663 -> 0.635 -> 0.615 -> 0.610
+(monotone decreasing); shipped described dNDCG is roughly flat to
+declining (0.755, 0.711, 0.644, 0.607, 0.607, 0.587) with one local
+recovery pattern in the middle (0.644 at 200 close to the 300 value) but
+overall non-increasing across the six points.

--- a/benchmark_data/corpus_search/modes_results.json
+++ b/benchmark_data/corpus_search/modes_results.json
@@ -7,8 +7,8 @@
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.35
+        "ndcg": 0.3333333333333333,
+        "seconds": 0.484
       },
       "described-02": {
         "cjk": false,
@@ -16,7 +16,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.37
+        "seconds": 0.48
       },
       "described-03": {
         "cjk": false,
@@ -24,7 +24,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.381
+        "seconds": 0.474
       },
       "described-04": {
         "cjk": false,
@@ -32,7 +32,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.334
+        "seconds": 0.464
       },
       "described-05": {
         "cjk": false,
@@ -40,31 +40,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.354
+        "seconds": 0.48
       },
       "described-06": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.35
+        "ndcg": 0.0,
+        "seconds": 0.464
       },
       "described-07": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.5,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.33
+        "seconds": 0.463
       },
       "described-08": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.332
+        "ndcg": 0.0,
+        "seconds": 0.463
       },
       "described-09": {
         "cjk": false,
@@ -72,23 +72,23 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.392
+        "seconds": 0.463
       },
       "described-10": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3562071871080222,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.342
+        "seconds": 0.463
       },
       "described-11": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.344
+        "ndcg": 0.3333333333333333,
+        "seconds": 0.459
       },
       "described-12": {
         "cjk": false,
@@ -96,15 +96,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.338
+        "seconds": 0.464
       },
       "described-13": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3333333333333333,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.375
+        "seconds": 0.461
       },
       "described-14": {
         "cjk": false,
@@ -112,7 +112,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.342
+        "seconds": 0.463
       },
       "described-15": {
         "cjk": false,
@@ -120,15 +120,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.611
+        "seconds": 0.462
       },
       "described-16": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3562071871080222,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.35
+        "seconds": 0.476
       },
       "described-17": {
         "cjk": false,
@@ -136,15 +136,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.366
+        "seconds": 0.569
       },
       "described-18": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.341
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.488
       },
       "described-19": {
         "cjk": false,
@@ -152,7 +152,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.368
+        "seconds": 0.483
       },
       "described-20": {
         "cjk": false,
@@ -160,15 +160,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.336
+        "seconds": 0.506
       },
       "described-21": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.347
+        "ndcg": 0.0,
+        "seconds": 0.519
       },
       "described-22": {
         "cjk": false,
@@ -176,31 +176,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.359
+        "seconds": 0.475
       },
       "described-23": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.332
+        "ndcg": 1.0,
+        "seconds": 0.468
       },
       "described-24": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.349
+        "seconds": 0.47
       },
       "described-25": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.341
+        "ndcg": 0.3010299956639812,
+        "seconds": 0.461
       },
       "needle-01": {
         "cjk": false,
@@ -208,7 +208,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.356
+        "seconds": 0.461
       },
       "needle-02": {
         "cjk": false,
@@ -216,7 +216,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.34
+        "seconds": 0.461
       },
       "needle-03": {
         "cjk": false,
@@ -224,7 +224,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.32
+        "seconds": 0.457
       },
       "needle-04": {
         "cjk": false,
@@ -232,7 +232,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.341
+        "seconds": 0.468
       },
       "needle-05": {
         "cjk": false,
@@ -240,7 +240,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.324
+        "seconds": 0.459
       },
       "needle-06": {
         "cjk": false,
@@ -248,7 +248,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.347
+        "seconds": 0.456
       },
       "needle-07": {
         "cjk": false,
@@ -256,15 +256,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.314
+        "seconds": 0.458
       },
       "needle-08": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.312
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.455
       },
       "needle-09": {
         "cjk": false,
@@ -272,7 +272,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.328
+        "seconds": 0.468
       },
       "needle-10": {
         "cjk": true,
@@ -280,15 +280,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.9502344167898356,
-        "seconds": 2.421
+        "seconds": 2.27
       },
       "needle-11": {
         "cjk": true,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 2.406
+        "ndcg": 0.5,
+        "seconds": 2.247
       },
       "needle-12": {
         "cjk": true,
@@ -296,721 +296,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 2.439
-      },
-      "needle-13": {
-        "cjk": true,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 2.446
-      },
-      "needle-14": {
-        "cjk": true,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 2.408
-      },
-      "spread-01": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.8670870086853021,
-        "dochit3": 1,
-        "ndcg": 0.17721732175293053,
-        "seconds": 0.314
-      },
-      "spread-02": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7653606369886217,
-        "dochit3": 1,
-        "ndcg": 0.2960819109658652,
-        "seconds": 0.353
-      },
-      "spread-03": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.5316519652587917,
-        "dochit3": 1,
-        "ndcg": 0.5316519652587917,
-        "seconds": 0.358
-      },
-      "spread-04": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.9197207891481876,
-        "dochit3": 1,
-        "ndcg": 0.23719771276929622,
-        "seconds": 0.332
-      },
-      "spread-05": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.5706417189553201,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.326
-      },
-      "spread-06": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.397
-      },
-      "spread-07": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.6131471927654584,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.352
-      },
-      "spread-08": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.3065735963827292,
-        "dochit3": 1,
-        "ndcg": 0.3065735963827292,
-        "seconds": 0.374
-      },
-      "spread-09": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.5307212739772434,
-        "dochit3": 1,
-        "ndcg": 0.30281242839865,
-        "seconds": 0.37
-      },
-      "spread-10": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.16771752171325524,
-        "dochit3": 0,
-        "ndcg": 0.16004318879660112,
-        "seconds": 0.357
-      },
-      "spread-11": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.8670870086853021,
-        "dochit3": 1,
-        "ndcg": 0.11448501924530576,
-        "seconds": 0.349
-      },
-      "spread-12": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.45560514958746035,
-        "seconds": 0.314
-      },
-      "spread-13": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.8921670734208305,
-        "dochit3": 1,
-        "ndcg": 0.15368188299909635,
-        "seconds": 0.362
-      },
-      "spread-14": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.9674679834891693,
-        "dochit3": 1,
-        "ndcg": 0.16716045496620227,
-        "seconds": 0.351
-      },
-      "spread-15": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7974779478881874,
-        "dochit3": 1,
-        "ndcg": 0.39668756020386675,
-        "seconds": 0.342
-      },
-      "spread-16": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
-        "dochit3": 1,
-        "ndcg": 0.4796249331362629,
-        "seconds": 0.323
-      },
-      "spread-17": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.8403030283801005,
-        "dochit3": 1,
-        "ndcg": 0.2129292954931993,
-        "seconds": 0.36
-      },
-      "spread-18": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.888747738037333,
-        "dochit3": 1,
-        "ndcg": 0.6993694869720469,
-        "seconds": 0.361
-      },
-      "spread-19": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.9502344167898356,
-        "dochit3": 1,
-        "ndcg": 0.14704034066641014,
-        "seconds": 0.338
-      },
-      "spread-20": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
-        "dochit3": 1,
-        "ndcg": 0.7601875334318685,
-        "seconds": 0.364
-      },
-      "spread-21": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6934264036172708,
-        "seconds": 0.322
-      },
-      "spread-22": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6131471927654584,
-        "seconds": 0.362
-      },
-      "spread-23": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.6461369845040973,
-        "dochit3": 1,
-        "ndcg": 0.3175786993670768,
-        "seconds": 0.348
-      },
-      "spread-24": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
-        "dochit3": 1,
-        "ndcg": 0.7601875334318685,
-        "seconds": 0.336
-      },
-      "spread-25": {
-        "cjk": false,
-        "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
-        "dochit3": 1,
-        "ndcg": 0.7601875334318685,
-        "seconds": 0.369
-      },
-      "trap-01": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.333
-      },
-      "trap-02": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.334
-      },
-      "trap-03": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.365
-      },
-      "trap-04": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.337
-      },
-      "trap-05": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.402
-      },
-      "trap-06": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.338
-      },
-      "trap-07": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.344
-      },
-      "trap-08": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.341
-      },
-      "trap-09": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.309
-      },
-      "trap-10": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.339
-      },
-      "trap-11": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.338
-      },
-      "trap-12": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.307
-      },
-      "trap-13": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.372
-      },
-      "trap-14": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.369
-      },
-      "trap-15": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.312
-      },
-      "trap-16": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.326
-      },
-      "trap-17": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.353
-      },
-      "trap-18": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.303
-      },
-      "trap-19": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.321
-      },
-      "trap-20": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.36
-      },
-      "trap-21": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.336
-      },
-      "trap-22": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.331
-      },
-      "trap-23": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.337
-      },
-      "trap-24": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.327
-      },
-      "trap-25": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.342
-      }
-    },
-    "keyword": {
-      "described-01": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.559
-      },
-      "described-02": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.563
-      },
-      "described-03": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.565
-      },
-      "described-04": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.554
-      },
-      "described-05": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.605
-      },
-      "described-06": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.55
-      },
-      "described-07": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.547
-      },
-      "described-08": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.566
-      },
-      "described-09": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.3562071871080222,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.576
-      },
-      "described-10": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.582
-      },
-      "described-11": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.548
-      },
-      "described-12": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.626
-      },
-      "described-13": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.556
-      },
-      "described-14": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.544
-      },
-      "described-15": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.532
-      },
-      "described-16": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.568
-      },
-      "described-17": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.585
-      },
-      "described-18": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.583
-      },
-      "described-19": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.5,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.605
-      },
-      "described-20": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.38685280723454163,
-        "dochit3": 0,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.557
-      },
-      "described-21": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.3333333333333333,
-        "dochit3": 0,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.553
-      },
-      "described-22": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.43067655807339306,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.554
-      },
-      "described-23": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.3333333333333333,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.553
-      },
-      "described-24": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 0.5,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.557
-      },
-      "described-25": {
-        "cjk": false,
-        "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.538
-      },
-      "needle-01": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.306
-      },
-      "needle-02": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.196
-      },
-      "needle-03": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.23
-      },
-      "needle-04": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.204
-      },
-      "needle-05": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.207
-      },
-      "needle-06": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.286
-      },
-      "needle-07": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.201
-      },
-      "needle-08": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.197
-      },
-      "needle-09": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.206
-      },
-      "needle-10": {
-        "cjk": true,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.9238850086262381,
-        "seconds": 2.275
-      },
-      "needle-11": {
-        "cjk": true,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 2.268
-      },
-      "needle-12": {
-        "cjk": true,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 2.269
+        "seconds": 2.238
       },
       "needle-13": {
         "cjk": true,
@@ -1026,55 +312,55 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 2.272
+        "seconds": 2.285
       },
       "spread-01": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.8670870086853021,
         "dochit3": 1,
-        "ndcg": 0.3101303130676284,
-        "seconds": 0.242
+        "ndcg": 0.3430601340643824,
+        "seconds": 0.461
       },
       "spread-02": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6257049680303419,
+        "doc_ndcg": 0.46927872602275644,
         "dochit3": 1,
-        "ndcg": 0.46927872602275644,
-        "seconds": 0.314
+        "ndcg": 0.0,
+        "seconds": 0.48
       },
       "spread-03": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.5316519652587917,
-        "dochit3": 1,
-        "ndcg": 0.5316519652587917,
-        "seconds": 0.332
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.469
       },
       "spread-04": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6131471927654584,
+        "doc_ndcg": 0.8503449055347546,
         "dochit3": 1,
-        "ndcg": 0.2640681225725909,
-        "seconds": 0.23
+        "ndcg": 0.23719771276929622,
+        "seconds": 0.455
       },
       "spread-05": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6052602440527057,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.233
+        "seconds": 0.461
       },
       "spread-06": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.20438239758848611,
-        "dochit3": 0,
-        "ndcg": 0.20438239758848611,
-        "seconds": 0.347
+        "doc_ndcg": 0.3065735963827292,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.473
       },
       "spread-07": {
         "cjk": false,
@@ -1082,143 +368,143 @@
         "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.312
+        "seconds": 0.474
       },
       "spread-08": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6131471927654584,
-        "dochit3": 1,
-        "ndcg": 0.6131471927654584,
-        "seconds": 0.308
+        "doc_ndcg": 0.19342640361727081,
+        "dochit3": 0,
+        "ndcg": 0.19342640361727081,
+        "seconds": 0.47
       },
       "spread-09": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7653606369886217,
+        "doc_ndcg": 0.4632423659320675,
         "dochit3": 1,
-        "ndcg": 0.4776237035032179,
-        "seconds": 0.339
+        "ndcg": 0.14126697285982898,
+        "seconds": 0.459
       },
       "spread-10": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.3950493062974106,
+        "doc_ndcg": 0.15368188299909635,
         "dochit3": 0,
-        "ndcg": 0.3950493062974106,
-        "seconds": 0.324
+        "ndcg": 0.0,
+        "seconds": 0.468
       },
       "spread-11": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.8302310645465178,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.08385876085662762,
-        "seconds": 0.292
+        "ndcg": 0.10283552761606227,
+        "seconds": 0.462
       },
       "spread-12": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5714285040141098,
-        "seconds": 0.252
+        "ndcg": 0.45560514958746035,
+        "seconds": 0.451
       },
       "spread-13": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.7974779478881874,
         "dochit3": 1,
-        "ndcg": 0.4504543336748442,
-        "seconds": 0.348
+        "ndcg": 0.0,
+        "seconds": 0.465
       },
       "spread-14": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7122630665145961,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.28
+        "ndcg": 0.14126697285982898,
+        "seconds": 0.456
       },
       "spread-15": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7974779478881874,
+        "doc_ndcg": 0.8935349950641011,
         "dochit3": 1,
-        "ndcg": 0.26582598262939583,
-        "seconds": 0.227
+        "ndcg": 0.18937825106528608,
+        "seconds": 0.462
       },
       "spread-16": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
-        "ndcg": 0.23981246656813146,
-        "seconds": 0.243
+        "ndcg": 0.4796249331362629,
+        "seconds": 0.452
       },
       "spread-17": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6641442115010363,
+        "doc_ndcg": 0.7224242270408039,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.275
+        "ndcg": 0.2275408362015762,
+        "seconds": 0.46
       },
       "spread-18": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6672406095331843,
+        "doc_ndcg": 0.8518080397362219,
         "dochit3": 1,
-        "ndcg": 0.564405081917122,
-        "seconds": 0.299
+        "ndcg": 0.685333848257888,
+        "seconds": 0.468
       },
       "spread-19": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6433224083306327,
+        "doc_ndcg": 0.626665273802673,
         "dochit3": 1,
-        "ndcg": 0.16369747519436975,
-        "seconds": 0.287
+        "ndcg": 0.0,
+        "seconds": 0.47
       },
       "spread-20": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
+        "doc_ndcg": 0.9072278740982787,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.311
+        "seconds": 0.477
       },
       "spread-21": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.4415801103577823,
-        "seconds": 0.234
+        "ndcg": 0.9197207891481876,
+        "seconds": 0.471
       },
       "spread-22": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5714285040141098,
-        "seconds": 0.302
+        "ndcg": 0.6131471927654584,
+        "seconds": 0.482
       },
       "spread-23": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6455653564941389,
+        "doc_ndcg": 0.4683480347412084,
         "dochit3": 1,
-        "ndcg": 0.13291299131469791,
-        "seconds": 0.295
+        "ndcg": 0.26582598262939583,
+        "seconds": 0.476
       },
       "spread-24": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
+        "doc_ndcg": 0.9502344167898356,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.272
+        "seconds": 0.456
       },
       "spread-25": {
         "cjk": false,
@@ -1226,7 +512,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.313
+        "seconds": 0.46
       },
       "trap-01": {
         "cjk": false,
@@ -1234,15 +520,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.211
+        "seconds": 0.458
       },
       "trap-02": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.193
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.501
       },
       "trap-03": {
         "cjk": false,
@@ -1250,7 +536,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.31
+        "seconds": 0.465
       },
       "trap-04": {
         "cjk": false,
@@ -1258,31 +544,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.208
+        "seconds": 0.483
       },
       "trap-05": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.212
+        "ndcg": 0.5,
+        "seconds": 0.479
       },
       "trap-06": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.191
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.476
       },
       "trap-07": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.52
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.481
       },
       "trap-08": {
         "cjk": false,
@@ -1290,31 +576,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.206
+        "seconds": 0.463
       },
       "trap-09": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.405
+        "ndcg": 0.3333333333333333,
+        "seconds": 0.459
       },
       "trap-10": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.208
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.463
       },
       "trap-11": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.197
+        "ndcg": 0.5,
+        "seconds": 0.462
       },
       "trap-12": {
         "cjk": false,
@@ -1322,7 +608,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.509
+        "seconds": 0.459
       },
       "trap-13": {
         "cjk": false,
@@ -1330,31 +616,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.217
+        "seconds": 0.462
       },
       "trap-14": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.298
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.452
       },
       "trap-15": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.195
+        "ndcg": 0.5,
+        "seconds": 0.454
       },
       "trap-16": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.196
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.456
       },
       "trap-17": {
         "cjk": false,
@@ -1362,15 +648,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.261
+        "seconds": 0.461
       },
       "trap-18": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.484
+        "ndcg": 1.0,
+        "seconds": 0.45
       },
       "trap-19": {
         "cjk": false,
@@ -1378,15 +664,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.242
+        "seconds": 0.453
       },
       "trap-20": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.217
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.459
       },
       "trap-21": {
         "cjk": false,
@@ -1394,7 +680,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.236
+        "seconds": 0.455
       },
       "trap-22": {
         "cjk": false,
@@ -1402,7 +688,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.198
+        "seconds": 0.457
       },
       "trap-23": {
         "cjk": false,
@@ -1410,7 +696,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.477
+        "seconds": 0.475
       },
       "trap-24": {
         "cjk": false,
@@ -1418,7 +704,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.521
+        "seconds": 0.479
       },
       "trap-25": {
         "cjk": false,
@@ -1426,7 +712,721 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.216
+        "seconds": 0.471
+      }
+    },
+    "keyword": {
+      "described-01": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.753
+      },
+      "described-02": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.786
+      },
+      "described-03": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.766
+      },
+      "described-04": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.789
+      },
+      "described-05": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.898
+      },
+      "described-06": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.782
+      },
+      "described-07": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.75
+      },
+      "described-08": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.786
+      },
+      "described-09": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.3562071871080222,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.767
+      },
+      "described-10": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.776
+      },
+      "described-11": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.754
+      },
+      "described-12": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.757
+      },
+      "described-13": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.783
+      },
+      "described-14": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 0.753
+      },
+      "described-15": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.754
+      },
+      "described-16": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.849
+      },
+      "described-17": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.762
+      },
+      "described-18": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.846
+      },
+      "described-19": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 0.792
+      },
+      "described-20": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.38685280723454163,
+        "dochit3": 0,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.787
+      },
+      "described-21": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 0.784
+      },
+      "described-22": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.43067655807339306,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.783
+      },
+      "described-23": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.3333333333333333,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.762
+      },
+      "described-24": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 0.788
+      },
+      "described-25": {
+        "cjk": false,
+        "class": "described",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.771
+      },
+      "needle-01": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.363
+      },
+      "needle-02": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.309
+      },
+      "needle-03": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.316
+      },
+      "needle-04": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.308
+      },
+      "needle-05": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.304
+      },
+      "needle-06": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.304
+      },
+      "needle-07": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.303
+      },
+      "needle-08": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.302
+      },
+      "needle-09": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.306
+      },
+      "needle-10": {
+        "cjk": true,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.9502344167898356,
+        "seconds": 2.098
+      },
+      "needle-11": {
+        "cjk": true,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.089
+      },
+      "needle-12": {
+        "cjk": true,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 2.099
+      },
+      "needle-13": {
+        "cjk": true,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 2.101
+      },
+      "needle-14": {
+        "cjk": true,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 2.08
+      },
+      "spread-01": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.3101303130676284,
+        "seconds": 0.309
+      },
+      "spread-02": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6257049680303419,
+        "dochit3": 1,
+        "ndcg": 0.46927872602275644,
+        "seconds": 0.325
+      },
+      "spread-03": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.5316519652587917,
+        "dochit3": 1,
+        "ndcg": 0.5316519652587917,
+        "seconds": 0.326
+      },
+      "spread-04": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6131471927654584,
+        "dochit3": 1,
+        "ndcg": 0.2640681225725909,
+        "seconds": 0.304
+      },
+      "spread-05": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.316
+      },
+      "spread-06": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.20438239758848611,
+        "dochit3": 0,
+        "ndcg": 0.20438239758848611,
+        "seconds": 0.326
+      },
+      "spread-07": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6131471927654584,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.332
+      },
+      "spread-08": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6131471927654584,
+        "dochit3": 1,
+        "ndcg": 0.6131471927654584,
+        "seconds": 0.332
+      },
+      "spread-09": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7653606369886217,
+        "dochit3": 1,
+        "ndcg": 0.4776237035032179,
+        "seconds": 0.319
+      },
+      "spread-10": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.3950493062974106,
+        "dochit3": 0,
+        "ndcg": 0.3950493062974106,
+        "seconds": 0.323
+      },
+      "spread-11": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.8302310645465178,
+        "dochit3": 1,
+        "ndcg": 0.08385876085662762,
+        "seconds": 0.328
+      },
+      "spread-12": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.5912352048230277,
+        "seconds": 0.309
+      },
+      "spread-13": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.4504543336748442,
+        "seconds": 0.312
+      },
+      "spread-14": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7122630665145961,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.316
+      },
+      "spread-15": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7974779478881874,
+        "dochit3": 1,
+        "ndcg": 0.26582598262939583,
+        "seconds": 0.306
+      },
+      "spread-16": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7601875334318685,
+        "dochit3": 1,
+        "ndcg": 0.23981246656813146,
+        "seconds": 0.306
+      },
+      "spread-17": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6641442115010363,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.317
+      },
+      "spread-18": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6672406095331843,
+        "dochit3": 1,
+        "ndcg": 0.564405081917122,
+        "seconds": 0.321
+      },
+      "spread-19": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6433224083306327,
+        "dochit3": 1,
+        "ndcg": 0.16369747519436975,
+        "seconds": 0.317
+      },
+      "spread-20": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7601875334318685,
+        "dochit3": 1,
+        "ndcg": 0.7601875334318685,
+        "seconds": 0.328
+      },
+      "spread-21": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.4415801103577823,
+        "seconds": 0.311
+      },
+      "spread-22": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.5714285040141098,
+        "seconds": 0.321
+      },
+      "spread-23": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.6455653564941389,
+        "dochit3": 1,
+        "ndcg": 0.13291299131469791,
+        "seconds": 0.326
+      },
+      "spread-24": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7601875334318685,
+        "dochit3": 1,
+        "ndcg": 0.7601875334318685,
+        "seconds": 0.319
+      },
+      "spread-25": {
+        "cjk": false,
+        "class": "spread",
+        "doc_ndcg": 0.7601875334318685,
+        "dochit3": 1,
+        "ndcg": 0.7601875334318685,
+        "seconds": 0.329
+      },
+      "trap-01": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.313
+      },
+      "trap-02": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.314
+      },
+      "trap-03": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.326
+      },
+      "trap-04": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.31
+      },
+      "trap-05": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.311
+      },
+      "trap-06": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.319
+      },
+      "trap-07": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.694
+      },
+      "trap-08": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.305
+      },
+      "trap-09": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.583
+      },
+      "trap-10": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.305
+      },
+      "trap-11": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.301
+      },
+      "trap-12": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.691
+      },
+      "trap-13": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.313
+      },
+      "trap-14": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.314
+      },
+      "trap-15": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.306
+      },
+      "trap-16": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.304
+      },
+      "trap-17": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.304
+      },
+      "trap-18": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.644
+      },
+      "trap-19": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.307
+      },
+      "trap-20": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.309
+      },
+      "trap-21": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.305
+      },
+      "trap-22": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.303
+      },
+      "trap-23": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.62
+      },
+      "trap-24": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.671
+      },
+      "trap-25": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.305
       }
     },
     "semantic": {
@@ -1436,7 +1436,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.248
+        "seconds": 0.232
       },
       "described-02": {
         "cjk": false,
@@ -1444,7 +1444,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.308
+        "seconds": 0.234
       },
       "described-03": {
         "cjk": false,
@@ -1452,7 +1452,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.291
+        "seconds": 0.236
       },
       "described-04": {
         "cjk": false,
@@ -1460,7 +1460,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.229
+        "seconds": 0.234
       },
       "described-05": {
         "cjk": false,
@@ -1468,31 +1468,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.248
+        "seconds": 0.236
       },
       "described-06": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.231
+        "ndcg": 0.0,
+        "seconds": 0.238
       },
       "described-07": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 0.5,
-        "dochit3": 1,
+        "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.229
+        "seconds": 0.234
       },
       "described-08": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.229
+        "ndcg": 0.3010299956639812,
+        "seconds": 0.232
       },
       "described-09": {
         "cjk": false,
@@ -1500,15 +1500,15 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.322
+        "seconds": 0.247
       },
       "described-10": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3562071871080222,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.239
+        "seconds": 0.245
       },
       "described-11": {
         "cjk": false,
@@ -1516,7 +1516,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.23
+        "seconds": 0.244
       },
       "described-12": {
         "cjk": false,
@@ -1524,15 +1524,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.233
+        "seconds": 0.247
       },
       "described-13": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3333333333333333,
+        "doc_ndcg": 0.3562071871080222,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.29
+        "seconds": 0.257
       },
       "described-14": {
         "cjk": false,
@@ -1540,7 +1540,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.228
+        "seconds": 0.247
       },
       "described-15": {
         "cjk": false,
@@ -1548,15 +1548,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.766
+        "seconds": 0.238
       },
       "described-16": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.3562071871080222,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.241
+        "seconds": 0.246
       },
       "described-17": {
         "cjk": false,
@@ -1564,7 +1564,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.261
+        "seconds": 0.241
       },
       "described-18": {
         "cjk": false,
@@ -1572,7 +1572,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.253
+        "seconds": 0.24
       },
       "described-19": {
         "cjk": false,
@@ -1580,7 +1580,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.286
+        "seconds": 0.241
       },
       "described-20": {
         "cjk": false,
@@ -1588,15 +1588,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.24
+        "seconds": 0.238
       },
       "described-21": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.255
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.238
       },
       "described-22": {
         "cjk": false,
@@ -1604,31 +1604,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.252
+        "seconds": 0.244
       },
       "described-23": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.228
+        "ndcg": 1.0,
+        "seconds": 0.239
       },
       "described-24": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.3562071871080222,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.254
+        "seconds": 0.242
       },
       "described-25": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.259
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.234
       },
       "needle-01": {
         "cjk": false,
@@ -1636,23 +1636,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.235
+        "seconds": 0.256
       },
       "needle-02": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.253
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.246
       },
       "needle-03": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.213
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.238
       },
       "needle-04": {
         "cjk": false,
@@ -1660,7 +1660,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.246
+        "seconds": 0.243
       },
       "needle-05": {
         "cjk": false,
@@ -1668,7 +1668,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.215
+        "seconds": 0.236
       },
       "needle-06": {
         "cjk": false,
@@ -1676,7 +1676,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.24
+        "seconds": 0.237
       },
       "needle-07": {
         "cjk": false,
@@ -1684,7 +1684,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.21
+        "seconds": 0.236
       },
       "needle-08": {
         "cjk": false,
@@ -1692,7 +1692,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.221
+        "seconds": 0.228
       },
       "needle-09": {
         "cjk": false,
@@ -1700,23 +1700,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.231
+        "seconds": 0.228
       },
       "needle-10": {
         "cjk": true,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.234
+        "ndcg": 0.9502344167898356,
+        "seconds": 0.231
       },
       "needle-11": {
         "cjk": true,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.239
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.235
       },
       "needle-12": {
         "cjk": true,
@@ -1724,23 +1724,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.26
+        "seconds": 0.233
       },
       "needle-13": {
         "cjk": true,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.252
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.227
       },
       "needle-14": {
         "cjk": true,
         "class": "needle",
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 0,
-        "ndcg": 0.2890648263178879,
-        "seconds": 0.24
+        "ndcg": 0.0,
+        "seconds": 0.232
       },
       "spread-01": {
         "cjk": false,
@@ -1748,7 +1748,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.2289700384906115,
-        "seconds": 0.207
+        "seconds": 0.229
       },
       "spread-02": {
         "cjk": false,
@@ -1756,7 +1756,7 @@
         "doc_ndcg": 0.20210734650054757,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.263
+        "seconds": 0.242
       },
       "spread-03": {
         "cjk": false,
@@ -1764,15 +1764,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.299
+        "seconds": 0.231
       },
       "spread-04": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.9197207891481876,
+        "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.215
+        "seconds": 0.228
       },
       "spread-05": {
         "cjk": false,
@@ -1780,15 +1780,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.231
+        "seconds": 0.23
       },
       "spread-06": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.23719771276929622,
+        "doc_ndcg": 0.3065735963827292,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.226
+        "seconds": 0.234
       },
       "spread-07": {
         "cjk": false,
@@ -1796,7 +1796,7 @@
         "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.254
+        "seconds": 0.229
       },
       "spread-08": {
         "cjk": false,
@@ -1804,15 +1804,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.269
+        "seconds": 0.232
       },
       "spread-09": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.20210734650054757,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.227
+        "seconds": 0.229
       },
       "spread-10": {
         "cjk": false,
@@ -1820,15 +1820,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.231
+        "seconds": 0.236
       },
       "spread-11": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.8302310645465178,
+        "doc_ndcg": 0.8069320812880308,
         "dochit3": 1,
-        "ndcg": 0.15368188299909635,
-        "seconds": 0.221
+        "ndcg": 0.0,
+        "seconds": 0.235
       },
       "spread-12": {
         "cjk": false,
@@ -1836,15 +1836,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.208
+        "seconds": 0.238
       },
       "spread-13": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.26582598262939583,
+        "doc_ndcg": 0.5031525651397657,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.226
+        "seconds": 0.243
       },
       "spread-14": {
         "cjk": false,
@@ -1852,7 +1852,7 @@
         "doc_ndcg": 0.7653606369886217,
         "dochit3": 1,
         "ndcg": 0.2960819109658652,
-        "seconds": 0.224
+        "seconds": 0.242
       },
       "spread-15": {
         "cjk": false,
@@ -1860,23 +1860,23 @@
         "doc_ndcg": 0.5316519652587917,
         "dochit3": 1,
         "ndcg": 0.18937825106528608,
-        "seconds": 0.258
+        "seconds": 0.239
       },
       "spread-16": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
-        "ndcg": 0.7601875334318685,
-        "seconds": 0.217
+        "ndcg": 0.4796249331362629,
+        "seconds": 0.239
       },
       "spread-17": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 0.7763433706236033,
         "dochit3": 1,
-        "ndcg": 0.4030302838010049,
-        "seconds": 0.237
+        "ndcg": 0.6387878864795979,
+        "seconds": 0.234
       },
       "spread-18": {
         "cjk": false,
@@ -1884,15 +1884,15 @@
         "doc_ndcg": 0.9651954696014428,
         "dochit3": 1,
         "ndcg": 0.5316519652587917,
-        "seconds": 0.257
+        "seconds": 0.233
       },
       "spread-19": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
-        "ndcg": 0.27078426295835145,
-        "seconds": 0.267
+        "ndcg": 0.22883924989280793,
+        "seconds": 0.229
       },
       "spread-20": {
         "cjk": false,
@@ -1900,7 +1900,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.4796249331362629,
-        "seconds": 0.226
+        "seconds": 0.229
       },
       "spread-21": {
         "cjk": false,
@@ -1908,39 +1908,39 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.226
+        "seconds": 0.233
       },
       "spread-22": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6509209298071326,
+        "doc_ndcg": 0.38685280723454163,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.261
+        "seconds": 0.233
       },
       "spread-23": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.6461369845040973,
+        "doc_ndcg": 0.6993694869720469,
         "dochit3": 1,
         "ndcg": 0.5316519652587917,
-        "seconds": 0.233
+        "seconds": 0.234
       },
       "spread-24": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.9502344167898356,
+        "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.224
+        "seconds": 0.229
       },
       "spread-25": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
-        "ndcg": 0.38009376671593426,
-        "seconds": 0.27
+        "ndcg": 0.7601875334318685,
+        "seconds": 0.231
       },
       "trap-01": {
         "cjk": false,
@@ -1948,7 +1948,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.248
+        "seconds": 0.233
       },
       "trap-02": {
         "cjk": false,
@@ -1956,15 +1956,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.238
+        "seconds": 0.23
       },
       "trap-03": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.445
+        "ndcg": 0.5,
+        "seconds": 0.232
       },
       "trap-04": {
         "cjk": false,
@@ -1972,23 +1972,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.227
+        "seconds": 0.228
       },
       "trap-05": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.291
+        "ndcg": 0.5,
+        "seconds": 0.234
       },
       "trap-06": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.241
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.226
       },
       "trap-07": {
         "cjk": false,
@@ -1996,7 +1996,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.21
+        "seconds": 0.227
       },
       "trap-08": {
         "cjk": false,
@@ -2004,15 +2004,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.244
+        "seconds": 0.231
       },
       "trap-09": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.209
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.236
       },
       "trap-10": {
         "cjk": false,
@@ -2020,7 +2020,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.226
+        "seconds": 0.232
       },
       "trap-11": {
         "cjk": false,
@@ -2028,25 +2028,9 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.224
+        "seconds": 0.233
       },
       "trap-12": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.2
-      },
-      "trap-13": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.293
-      },
-      "trap-14": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
@@ -2054,13 +2038,29 @@
         "ndcg": 0.3562071871080222,
         "seconds": 0.228
       },
+      "trap-13": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.229
+      },
+      "trap-14": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.229
+      },
       "trap-15": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.202
+        "ndcg": 1.0,
+        "seconds": 0.228
       },
       "trap-16": {
         "cjk": false,
@@ -2068,15 +2068,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.226
+        "seconds": 0.231
       },
       "trap-17": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.244
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.239
       },
       "trap-18": {
         "cjk": false,
@@ -2084,7 +2084,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.201
+        "seconds": 0.226
       },
       "trap-19": {
         "cjk": false,
@@ -2092,15 +2092,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.2
+        "seconds": 0.227
       },
       "trap-20": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.228
+        "ndcg": 0.5,
+        "seconds": 0.229
       },
       "trap-21": {
         "cjk": false,
@@ -2108,7 +2108,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.241
+        "seconds": 0.231
       },
       "trap-22": {
         "cjk": false,
@@ -2116,7 +2116,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.223
+        "seconds": 0.237
       },
       "trap-23": {
         "cjk": false,
@@ -2124,7 +2124,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.244
+        "seconds": 0.237
       },
       "trap-24": {
         "cjk": false,
@@ -2132,79 +2132,66 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.226
+        "seconds": 0.231
       },
       "trap-25": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.238
+        "ndcg": 1.0,
+        "seconds": 0.234
       }
     }
   },
   "queries": 89,
-  "single_doc": {
-    "auto": {
-      "n": 64,
-      "ndcg": 0.7571
-    },
-    "keyword": {
-      "n": 64,
-      "ndcg": 0.7101
-    },
-    "semantic": {
-      "n": 64,
-      "ndcg": 0.6838
-    }
-  },
+  "single_doc": {},
   "summary": {
     "auto": {
       "by_class": {
         "described": {
-          "doc_ndcg": 0.6975,
+          "doc_ndcg": 0.7548,
           "dochit3": 0.72,
           "n": 25,
-          "ndcg": 0.2411
+          "ndcg": 0.2142
         },
         "needle": {
           "doc_ndcg": 1.0,
           "dochit3": 1.0,
           "n": 14,
-          "ndcg": 0.9964
+          "ndcg": 0.9344
         },
         "spread": {
-          "doc_ndcg": 0.7265,
-          "dochit3": 0.92,
+          "doc_ndcg": 0.6904,
+          "dochit3": 0.88,
           "n": 25,
-          "ndcg": 0.3497
+          "ndcg": 0.291
         },
         "trap": {
           "doc_ndcg": 1.0,
           "dochit3": 1.0,
           "n": 25,
-          "ndcg": 0.7756
+          "ndcg": 0.7164
         }
       },
       "cjk_subset": {
         "doc_ndcg": 1.0,
         "dochit3": 1.0,
         "n": 5,
-        "ndcg": 0.99
+        "ndcg": 0.89
       },
-      "mean_query_seconds": 0.465,
+      "mean_query_seconds": 0.569,
       "non_cjk": {
-        "doc_ndcg": 0.8286,
-        "dochit3": 0.8929,
+        "doc_ndcg": 0.8349,
+        "dochit3": 0.881,
         "n": 84,
-        "ndcg": 0.5138
+        "ndcg": 0.4663
       },
       "overall": {
-        "doc_ndcg": 0.8382,
-        "dochit3": 0.8989,
+        "doc_ndcg": 0.8442,
+        "dochit3": 0.8876,
         "n": 89,
-        "ndcg": 0.5406
+        "ndcg": 0.4901
       },
       "search_mode_reported": [
         "hybrid"
@@ -2213,48 +2200,48 @@
     "keyword": {
       "by_class": {
         "described": {
-          "doc_ndcg": 0.4946,
-          "dochit3": 0.52,
+          "doc_ndcg": 0.496,
+          "dochit3": 0.56,
           "n": 25,
-          "ndcg": 0.134
+          "ndcg": 0.1355
         },
         "needle": {
           "doc_ndcg": 1.0,
           "dochit3": 1.0,
           "n": 14,
-          "ndcg": 0.9682
+          "ndcg": 0.9437
         },
         "spread": {
           "doc_ndcg": 0.7345,
           "dochit3": 0.92,
           "n": 25,
-          "ndcg": 0.3613
+          "ndcg": 0.362
         },
         "trap": {
-          "doc_ndcg": 0.96,
-          "dochit3": 0.96,
+          "doc_ndcg": 1.0,
+          "dochit3": 1.0,
           "n": 25,
-          "ndcg": 0.5964
+          "ndcg": 0.6119
         }
       },
       "cjk_subset": {
         "doc_ndcg": 1.0,
         "dochit3": 1.0,
         "n": 5,
-        "ndcg": 0.9848
+        "ndcg": 0.9162
       },
-      "mean_query_seconds": 0.47,
+      "mean_query_seconds": 0.569,
       "non_cjk": {
-        "doc_ndcg": 0.7587,
-        "dochit3": 0.8214,
+        "doc_ndcg": 0.771,
+        "dochit3": 0.8452,
         "n": 84,
-        "ndcg": 0.4277
+        "ndcg": 0.4329
       },
       "overall": {
-        "doc_ndcg": 0.7722,
-        "dochit3": 0.8315,
+        "doc_ndcg": 0.7838,
+        "dochit3": 0.8539,
         "n": 89,
-        "ndcg": 0.459
+        "ndcg": 0.4601
       },
       "search_mode_reported": [
         "keyword"
@@ -2263,48 +2250,48 @@
     "semantic": {
       "by_class": {
         "described": {
-          "doc_ndcg": 0.6975,
-          "dochit3": 0.72,
+          "doc_ndcg": 0.7299,
+          "dochit3": 0.64,
           "n": 25,
-          "ndcg": 0.2411
+          "ndcg": 0.2282
         },
         "needle": {
-          "doc_ndcg": 0.9736,
+          "doc_ndcg": 0.9473,
           "dochit3": 0.9286,
           "n": 14,
-          "ndcg": 0.8608
+          "ndcg": 0.754
         },
         "spread": {
-          "doc_ndcg": 0.5758,
+          "doc_ndcg": 0.5669,
           "dochit3": 0.72,
           "n": 25,
-          "ndcg": 0.2149
+          "ndcg": 0.2205
         },
         "trap": {
           "doc_ndcg": 1.0,
           "dochit3": 1.0,
           "n": 25,
-          "ndcg": 0.7848
+          "ndcg": 0.7821
         }
       },
       "cjk_subset": {
         "doc_ndcg": 0.9262,
         "dochit3": 0.8,
         "n": 5,
-        "ndcg": 0.684
+        "ndcg": 0.5325
       },
-      "mean_query_seconds": 0.249,
+      "mean_query_seconds": 0.235,
       "non_cjk": {
-        "doc_ndcg": 0.7837,
-        "dochit3": 0.8333,
+        "doc_ndcg": 0.7863,
+        "dochit3": 0.8095,
         "n": 84,
-        "ndcg": 0.472
+        "ndcg": 0.4603
       },
       "overall": {
-        "doc_ndcg": 0.7917,
-        "dochit3": 0.8315,
+        "doc_ndcg": 0.7942,
+        "dochit3": 0.809,
         "n": 89,
-        "ndcg": 0.484
+        "ndcg": 0.4643
       },
       "search_mode_reported": [
         "semantic"

--- a/benchmark_data/corpus_search/modes_results.md
+++ b/benchmark_data/corpus_search/modes_results.md
@@ -118,3 +118,5 @@ This benchmark's `--single-doc-arm` flag was not passed on this pass, so
 no single-doc `pdf_search` figures were regenerated here. The
 previously published single-doc numbers stand: `pdf_search` is untouched
 by the document-arm work on this branch.
+
+Size dependence of the document arm (50 to 500 documents, same cache, control vs arm): `doc_arm_size_sweep.md`.

--- a/benchmark_data/corpus_search/modes_results.md
+++ b/benchmark_data/corpus_search/modes_results.md
@@ -27,20 +27,49 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 | auto | 0.890 | 0.466 |
 
 Sanity cross-check: compare keyword overall against the stage-2 arm-B reference (~0.547) only on the 64 non-`described` queries. The 89-query overall includes `described`, where keyword scores ~0.13, so it lands well below the reference on query mix alone. Interpretation is appended by hand after the run.
-## Interpretation (89-query run; cite the tables above, not this prose)
+## Interpretation (89-query run, document arm live; cite the tables above, not this prose)
 
-Hybrid is the strongest mode on every cut: page NDCG@10 0.541,
-doc-NDCG@10 0.838, doc-hit@3 0.899, needle 0.996. The arms complement as
-designed: semantic is near-immune to lexical traps (0.785 vs keyword's
-0.596) and keyword anchors literal precision (needle 0.968). Every mode
-runs in under half a second per query on a warmed 100-doc corpus.
+Hybrid is the strongest mode on every cut: page NDCG@10 0.490,
+doc-NDCG@10 0.844, doc-hit@3 0.888, needle page-NDCG 0.934. The arms
+complement as designed: semantic is near-immune to lexical traps (0.782
+vs keyword's 0.612) and keyword anchors literal precision (needle
+0.944). Every mode runs in about half a second per query on a warmed
+100-doc corpus.
 
 `described` is the binding constraint, not corpus size. Every mode scores
-0.24 or below on it (hybrid 0.241, keyword 0.134) and it is a quarter of
-the query set, so it sets the page-level overall almost by itself.
-Doc-level holds at 0.838, which is the label-sparsity gap the doc-level
-table exists to separate: the right document is being found, the graded
-page inside it often is not.
+0.23 or below on it at the page level (auto 0.214, semantic 0.228,
+keyword 0.136) and it is a quarter of the query set, so it sets the
+page-level overall almost by itself. Doc-level holds at 0.844, which is
+the label-sparsity gap the doc-level table exists to separate: the right
+document is being found, the graded page inside it often is not.
+
+### Comparability: this run is not the Aug-23 file
+
+This 89-query run and the committed Aug-23 `modes_results.json`
+(`7ef552f`) came from different cache warms and are not comparable
+number for number, even where a mode's code did not change. The
+semantic arm carries no code change on this branch, yet needle
+page-NDCG reads 0.754 in both of today's runs (pre-arm and post-arm)
+against 0.861 in the Aug-23 file. Treat any Aug-23-vs-today delta as
+warm-to-warm noise, not a measured effect.
+
+The document arm's own effect is instead measured same-day: a pre-arm
+re-run on unmodified `develop`, immediately followed by this post-arm
+run, both on this machine on 2026-08-29. See the "100-doc gate" section
+below for the paired numbers.
+
+### 100-doc gate: same-day pre-arm re-run vs. post-arm
+
+| class | pre-arm (same-day re-run) doc-hit@3 | post-arm doc-hit@3 | pre-arm doc-NDCG@10 | post-arm doc-NDCG@10 | gate |
+|---|---|---|---|---|---|
+| described | 0.640 (16/25) | 0.720 (18/25) | 0.730 | 0.755 | PASS |
+| spread | 0.920 (23/25) | 0.880 (22/25) | 0.722 | 0.690 | PASS (down 1 query) |
+| needle | 1.000 (14/14) | 1.000 (14/14) | 1.000 | 1.000 | PASS (>= 0.98) |
+| trap | 1.000 (25/25) | 1.000 (25/25) | 1.000 | 1.000 | PASS (>= 0.98) |
+
+Gate: needle and trap doc-hit@3 >= 0.98, and no class down more than one
+query. `spread` moved by exactly one query (23/25 -> 22/25); every other
+class held or improved. All PASS.
 
 ### Do not cite 0.674 / doc-hit@3 1.000
 
@@ -75,10 +104,17 @@ corpus reproduces it.
 
 The stage-2 arm-B reference (~0.547) was matched by the 64-query run's
 keyword overall. It is not comparable to the 89-query keyword overall
-(0.459), which includes `described` at 0.134. On the 64-query subset this
+(0.460), which includes `described` at 0.136. On the 64-query subset this
 run's keyword overall is 0.586, above the reference, as expected after
 the two keyword fixes.
 
 History: the pre-fix CJK record and that bug's narrative are in this
 file's git history (commit `07cbff2`); the 64-query numbers are in
 `040df8b`.
+
+## Single-doc arm not re-run
+
+This benchmark's `--single-doc-arm` flag was not passed on this pass, so
+no single-doc `pdf_search` figures were regenerated here. The
+previously published single-doc numbers stand: `pdf_search` is untouched
+by the document-arm work on this branch.

--- a/benchmark_data/corpus_search/modes_results.md
+++ b/benchmark_data/corpus_search/modes_results.md
@@ -4,9 +4,9 @@ Corpus: 100 docs. Queries: 89 (graded ground truth, stage-2). top_k=10. The tool
 
 | mode | overall NDCG@10 | described | needle | spread | trap | doc-hit@3 | s/query |
 |---|---|---|---|---|---|---|---|
-| keyword (keyword) | 0.459 | 0.134 | 0.968 | 0.361 | 0.596 | 0.832 | 0.47 |
-| semantic (semantic) | 0.484 | 0.241 | 0.861 | 0.215 | 0.785 | 0.832 | 0.25 |
-| auto (hybrid) | 0.541 | 0.241 | 0.996 | 0.350 | 0.776 | 0.899 | 0.47 |
+| keyword (keyword) | 0.460 | 0.136 | 0.944 | 0.362 | 0.612 | 0.854 | 0.57 |
+| semantic (semantic) | 0.464 | 0.228 | 0.754 | 0.221 | 0.782 | 0.809 | 0.23 |
+| auto (hybrid) | 0.490 | 0.214 | 0.934 | 0.291 | 0.716 | 0.888 | 0.57 |
 
 ## Doc-level NDCG@10 (ranked docs deduped, gain = doc's best label)
 
@@ -14,30 +14,19 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 
 | mode | overall | described | needle | spread | trap |
 |---|---|---|---|---|---|
-| keyword | 0.772 | 0.495 | 1.000 | 0.735 | 0.960 |
-| semantic | 0.792 | 0.698 | 0.974 | 0.576 | 1.000 |
-| auto | 0.838 | 0.698 | 1.000 | 0.727 | 1.000 |
+| keyword | 0.784 | 0.496 | 1.000 | 0.735 | 1.000 |
+| semantic | 0.794 | 0.730 | 0.947 | 0.567 | 1.000 |
+| auto | 0.844 | 0.755 | 1.000 | 0.690 | 1.000 |
 
 ## CJK subset (5 needle queries on Japanese docs; embedding model is English bge-small, so the semantic arm is expected to be weak there)
 
 | mode | CJK NDCG@10 (n=5) | non-CJK NDCG@10 |
 |---|---|---|
-| keyword | 0.985 | 0.428 |
-| semantic | 0.684 | 0.472 |
-| auto | 0.990 | 0.514 |
-
-## Single-doc arm (pdf_search against the one gold document)
-
-The common agent flow: a question asked of a single known document, not the whole corpus. Same page labels, restricted to queries whose gold pages sit in exactly one document.
-
-| mode | NDCG@10 | n |
-|---|---|---|
-| keyword | 0.710 | 64 |
-| semantic | 0.684 | 64 |
-| auto | 0.757 | 64 |
+| keyword | 0.916 | 0.433 |
+| semantic | 0.532 | 0.460 |
+| auto | 0.890 | 0.466 |
 
 Sanity cross-check: compare keyword overall against the stage-2 arm-B reference (~0.547) only on the 64 non-`described` queries. The 89-query overall includes `described`, where keyword scores ~0.13, so it lands well below the reference on query mix alone. Interpretation is appended by hand after the run.
-
 ## Interpretation (89-query run; cite the tables above, not this prose)
 
 Hybrid is the strongest mode on every cut: page NDCG@10 0.541,

--- a/benchmark_data/corpus_search/modes_results_500.json
+++ b/benchmark_data/corpus_search/modes_results_500.json
@@ -7,16 +7,16 @@
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 1.501
+        "ndcg": 0.2890648263178879,
+        "seconds": 2.744
       },
       "described-02": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.5,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.511
+        "seconds": 2.431
       },
       "described-03": {
         "cjk": false,
@@ -24,7 +24,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.487
+        "seconds": 2.877
       },
       "described-04": {
         "cjk": false,
@@ -32,7 +32,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.528
+        "seconds": 2.439
       },
       "described-05": {
         "cjk": false,
@@ -40,7 +40,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.501
+        "seconds": 2.364
       },
       "described-06": {
         "cjk": false,
@@ -48,31 +48,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.528
+        "seconds": 2.395
       },
       "described-07": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.495
+        "seconds": 2.452
       },
       "described-08": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3010299956639812,
-        "seconds": 1.555
+        "ndcg": 0.0,
+        "seconds": 2.388
       },
       "described-09": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 0.5,
-        "dochit3": 0,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.491
+        "seconds": 2.371
       },
       "described-10": {
         "cjk": false,
@@ -80,23 +80,23 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.516
+        "seconds": 2.396
       },
       "described-11": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 1.496
+        "ndcg": 0.3010299956639812,
+        "seconds": 2.409
       },
       "described-12": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.533
+        "seconds": 2.361
       },
       "described-13": {
         "cjk": false,
@@ -104,15 +104,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.511
+        "seconds": 2.552
       },
       "described-14": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.43067655807339306,
-        "seconds": 1.531
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.684
       },
       "described-15": {
         "cjk": false,
@@ -120,7 +120,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.488
+        "seconds": 2.648
       },
       "described-16": {
         "cjk": false,
@@ -128,7 +128,7 @@
         "doc_ndcg": 0.3562071871080222,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.527
+        "seconds": 2.385
       },
       "described-17": {
         "cjk": false,
@@ -136,7 +136,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.493
+        "seconds": 2.656
       },
       "described-18": {
         "cjk": false,
@@ -144,7 +144,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.51
+        "seconds": 2.493
       },
       "described-19": {
         "cjk": false,
@@ -152,23 +152,23 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.485
+        "seconds": 2.558
       },
       "described-20": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.43067655807339306,
-        "seconds": 1.498
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.621
       },
       "described-21": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 0.5,
-        "dochit3": 0,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.5
+        "seconds": 2.503
       },
       "described-22": {
         "cjk": false,
@@ -176,31 +176,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.51
+        "seconds": 2.418
       },
       "described-23": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.38685280723454163,
-        "dochit3": 0,
-        "ndcg": 0.38685280723454163,
-        "seconds": 1.491
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 2.476
       },
       "described-24": {
         "cjk": false,
         "class": "described",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.515
+        "seconds": 2.627
       },
       "described-25": {
         "cjk": false,
         "class": "described",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 1.51
+        "ndcg": 0.3010299956639812,
+        "seconds": 2.458
       },
       "needle-01": {
         "cjk": false,
@@ -208,7 +208,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.526
+        "seconds": 2.475
       },
       "needle-02": {
         "cjk": false,
@@ -216,7 +216,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.528
+        "seconds": 2.341
       },
       "needle-03": {
         "cjk": false,
@@ -224,7 +224,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.512
+        "seconds": 2.316
       },
       "needle-04": {
         "cjk": false,
@@ -232,7 +232,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.492
+        "seconds": 2.356
       },
       "needle-05": {
         "cjk": false,
@@ -240,7 +240,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.506
+        "seconds": 2.373
       },
       "needle-06": {
         "cjk": false,
@@ -248,7 +248,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.515
+        "seconds": 2.34
       },
       "needle-07": {
         "cjk": false,
@@ -256,15 +256,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.515
+        "seconds": 2.341
       },
       "needle-08": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 1.495
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.362
       },
       "needle-09": {
         "cjk": false,
@@ -272,7 +272,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.517
+        "seconds": 2.363
       },
       "needle-10": {
         "cjk": true,
@@ -280,7 +280,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.9502344167898356,
-        "seconds": 12.766
+        "seconds": 12.346
       },
       "needle-11": {
         "cjk": true,
@@ -288,7 +288,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 12.998
+        "seconds": 12.372
       },
       "needle-12": {
         "cjk": true,
@@ -296,7 +296,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.823
+        "seconds": 12.24
       },
       "needle-13": {
         "cjk": true,
@@ -304,7 +304,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.765
+        "seconds": 12.339
       },
       "needle-14": {
         "cjk": true,
@@ -312,15 +312,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.7
+        "seconds": 12.335
       },
       "spread-01": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.8670870086853021,
         "dochit3": 1,
-        "ndcg": 0.2662191925648343,
-        "seconds": 1.523
+        "ndcg": 0.3430601340643824,
+        "seconds": 2.324
       },
       "spread-02": {
         "cjk": false,
@@ -328,7 +328,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.591
+        "seconds": 2.402
       },
       "spread-03": {
         "cjk": false,
@@ -336,7 +336,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.523
+        "seconds": 2.341
       },
       "spread-04": {
         "cjk": false,
@@ -344,15 +344,15 @@
         "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.23719771276929622,
-        "seconds": 1.519
+        "seconds": 2.333
       },
       "spread-05": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.5437713091520254,
+        "doc_ndcg": 0.5912352048230277,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.49
+        "seconds": 2.35
       },
       "spread-06": {
         "cjk": false,
@@ -360,7 +360,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.567
+        "seconds": 2.394
       },
       "spread-07": {
         "cjk": false,
@@ -368,7 +368,7 @@
         "doc_ndcg": 0.23719771276929622,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.606
+        "seconds": 3.066
       },
       "spread-08": {
         "cjk": false,
@@ -376,15 +376,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.609
+        "seconds": 2.941
       },
       "spread-09": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.4776237035032179,
+        "doc_ndcg": 0.4525081529734507,
         "dochit3": 1,
-        "ndcg": 0.16716045496620227,
-        "seconds": 1.517
+        "ndcg": 0.14126697285982898,
+        "seconds": 2.623
       },
       "spread-10": {
         "cjk": false,
@@ -392,23 +392,23 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.5
+        "seconds": 2.405
       },
       "spread-11": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.33858404654682245,
-        "dochit3": 0,
+        "doc_ndcg": 0.6107608260955816,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.493
+        "seconds": 2.552
       },
       "spread-12": {
         "cjk": false,
         "class": "spread",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5249810332008933,
-        "seconds": 1.492
+        "ndcg": 0.4911492931622974,
+        "seconds": 2.378
       },
       "spread-13": {
         "cjk": false,
@@ -416,23 +416,23 @@
         "doc_ndcg": 0.5316519652587917,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.503
+        "seconds": 2.409
       },
       "spread-14": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.9325210919548239,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.16716045496620227,
-        "seconds": 1.512
+        "ndcg": 0.13565197343244778,
+        "seconds": 2.436
       },
       "spread-15": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7974779478881874,
+        "doc_ndcg": 0.8634575313654654,
         "dochit3": 1,
-        "ndcg": 0.39668756020386675,
-        "seconds": 1.462
+        "ndcg": 0.3430601340643824,
+        "seconds": 2.417
       },
       "spread-16": {
         "cjk": false,
@@ -440,31 +440,31 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.4796249331362629,
-        "seconds": 1.492
+        "seconds": 2.449
       },
       "spread-17": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.8403030283801005,
+        "doc_ndcg": 0.7224242270408039,
         "dochit3": 1,
-        "ndcg": 0.27511096828801057,
-        "seconds": 1.48
+        "ndcg": 0.31939394323979897,
+        "seconds": 2.444
       },
       "spread-18": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.32365916402325456,
-        "dochit3": 0,
-        "ndcg": 0.2289700384906115,
-        "seconds": 1.513
+        "doc_ndcg": 0.26582598262939583,
+        "dochit3": 1,
+        "ndcg": 0.26582598262939583,
+        "seconds": 2.451
       },
       "spread-19": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.4796249331362629,
+        "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.477
+        "seconds": 2.423
       },
       "spread-20": {
         "cjk": false,
@@ -472,7 +472,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 1.524
+        "seconds": 2.465
       },
       "spread-21": {
         "cjk": false,
@@ -480,31 +480,31 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.9197207891481876,
-        "seconds": 1.471
+        "seconds": 2.51
       },
       "spread-22": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.21840743681816419,
+        "doc_ndcg": 0.2640681225725909,
         "dochit3": 0,
-        "ndcg": 0.21840743681816419,
-        "seconds": 1.503
+        "ndcg": 0.2640681225725909,
+        "seconds": 2.469
       },
       "spread-23": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.3354350434265105,
+        "doc_ndcg": 0.6263410907914347,
         "dochit3": 1,
-        "ndcg": 0.3354350434265105,
-        "seconds": 1.504
+        "ndcg": 0.5316519652587917,
+        "seconds": 2.437
       },
       "spread-24": {
         "cjk": false,
         "class": "spread",
-        "doc_ndcg": 0.7601875334318685,
+        "doc_ndcg": 0.8800937667159342,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 1.517
+        "seconds": 2.44
       },
       "spread-25": {
         "cjk": false,
@@ -512,15 +512,15 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 1.496
+        "seconds": 2.4
       },
       "trap-01": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 1.68
+        "ndcg": 0.0,
+        "seconds": 2.834
       },
       "trap-02": {
         "cjk": false,
@@ -528,7 +528,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 1.697
+        "seconds": 2.545
       },
       "trap-03": {
         "cjk": false,
@@ -536,7 +536,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.56
+        "seconds": 2.454
       },
       "trap-04": {
         "cjk": false,
@@ -544,7 +544,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.53
+        "seconds": 2.471
       },
       "trap-05": {
         "cjk": false,
@@ -552,23 +552,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 1.514
+        "seconds": 2.429
       },
       "trap-06": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 1.542
+        "ndcg": 0.31546487678572877,
+        "seconds": 2.388
       },
       "trap-07": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 1.502
+        "ndcg": 0.38685280723454163,
+        "seconds": 2.403
       },
       "trap-08": {
         "cjk": false,
@@ -576,15 +576,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.548
+        "seconds": 2.406
       },
       "trap-09": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 1.481
+        "ndcg": 0.3333333333333333,
+        "seconds": 2.411
       },
       "trap-10": {
         "cjk": false,
@@ -592,7 +592,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.43067655807339306,
-        "seconds": 1.511
+        "seconds": 2.423
       },
       "trap-11": {
         "cjk": false,
@@ -600,15 +600,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 1.498
+        "seconds": 2.486
       },
       "trap-12": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 1.496
+        "ndcg": 0.2890648263178879,
+        "seconds": 2.485
       },
       "trap-13": {
         "cjk": false,
@@ -616,15 +616,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.534
+        "seconds": 2.366
       },
       "trap-14": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.31546487678572877,
-        "seconds": 1.495
+        "ndcg": 0.0,
+        "seconds": 2.444
       },
       "trap-15": {
         "cjk": false,
@@ -632,7 +632,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 1.501
+        "seconds": 2.404
       },
       "trap-16": {
         "cjk": false,
@@ -640,15 +640,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 1.471
+        "seconds": 2.378
       },
       "trap-17": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 1.504
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.356
       },
       "trap-18": {
         "cjk": false,
@@ -656,7 +656,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.474
+        "seconds": 2.383
       },
       "trap-19": {
         "cjk": false,
@@ -664,15 +664,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.49
+        "seconds": 2.433
       },
       "trap-20": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 1.478
+        "ndcg": 0.6309297535714575,
+        "seconds": 2.423
       },
       "trap-21": {
         "cjk": false,
@@ -680,7 +680,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.551
+        "seconds": 2.43
       },
       "trap-22": {
         "cjk": false,
@@ -688,7 +688,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.473
+        "seconds": 2.501
       },
       "trap-23": {
         "cjk": false,
@@ -696,7 +696,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.498
+        "seconds": 2.488
       },
       "trap-24": {
         "cjk": false,
@@ -704,7 +704,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.474
+        "seconds": 2.369
       },
       "trap-25": {
         "cjk": false,
@@ -712,7 +712,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.506
+        "seconds": 2.734
       }
     },
     "keyword": {
@@ -722,7 +722,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 2.402
+        "seconds": 4.02
       },
       "described-02": {
         "cjk": false,
@@ -730,7 +730,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.44
+        "seconds": 4.116
       },
       "described-03": {
         "cjk": false,
@@ -738,7 +738,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 2.397
+        "seconds": 4.123
       },
       "described-04": {
         "cjk": false,
@@ -746,7 +746,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.404
+        "seconds": 4.095
       },
       "described-05": {
         "cjk": false,
@@ -754,7 +754,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 2.527
+        "seconds": 4.477
       },
       "described-06": {
         "cjk": false,
@@ -762,7 +762,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.399
+        "seconds": 4.105
       },
       "described-07": {
         "cjk": false,
@@ -770,7 +770,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 2.34
+        "seconds": 4.078
       },
       "described-08": {
         "cjk": false,
@@ -778,7 +778,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.431
+        "seconds": 4.176
       },
       "described-09": {
         "cjk": false,
@@ -786,7 +786,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.406
+        "seconds": 4.189
       },
       "described-10": {
         "cjk": false,
@@ -794,7 +794,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.411
+        "seconds": 4.136
       },
       "described-11": {
         "cjk": false,
@@ -802,7 +802,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.357
+        "seconds": 4.044
       },
       "described-12": {
         "cjk": false,
@@ -810,7 +810,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.354
+        "seconds": 4.005
       },
       "described-13": {
         "cjk": false,
@@ -818,7 +818,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.426
+        "seconds": 4.188
       },
       "described-14": {
         "cjk": false,
@@ -826,7 +826,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.361
+        "seconds": 3.976
       },
       "described-15": {
         "cjk": false,
@@ -834,7 +834,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.361
+        "seconds": 3.985
       },
       "described-16": {
         "cjk": false,
@@ -842,7 +842,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.504
+        "seconds": 4.364
       },
       "described-17": {
         "cjk": false,
@@ -850,7 +850,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.346
+        "seconds": 4.051
       },
       "described-18": {
         "cjk": false,
@@ -858,7 +858,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.504
+        "seconds": 4.404
       },
       "described-19": {
         "cjk": false,
@@ -866,7 +866,7 @@
         "doc_ndcg": 0.31546487678572877,
         "dochit3": 0,
         "ndcg": 0.31546487678572877,
-        "seconds": 2.451
+        "seconds": 4.219
       },
       "described-20": {
         "cjk": false,
@@ -874,7 +874,7 @@
         "doc_ndcg": 0.2890648263178879,
         "dochit3": 0,
         "ndcg": 0.2890648263178879,
-        "seconds": 2.451
+        "seconds": 4.164
       },
       "described-21": {
         "cjk": false,
@@ -882,7 +882,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.423
+        "seconds": 4.17
       },
       "described-22": {
         "cjk": false,
@@ -890,7 +890,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.445
+        "seconds": 4.148
       },
       "described-23": {
         "cjk": false,
@@ -898,7 +898,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.413
+        "seconds": 4.1
       },
       "described-24": {
         "cjk": false,
@@ -906,7 +906,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 2.454
+        "seconds": 4.204
       },
       "described-25": {
         "cjk": false,
@@ -914,7 +914,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 2.422
+        "seconds": 4.115
       },
       "needle-01": {
         "cjk": false,
@@ -922,7 +922,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.058
+        "seconds": 1.665
       },
       "needle-02": {
         "cjk": false,
@@ -930,7 +930,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.029
+        "seconds": 1.614
       },
       "needle-03": {
         "cjk": false,
@@ -938,7 +938,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.001
+        "seconds": 1.649
       },
       "needle-04": {
         "cjk": false,
@@ -946,7 +946,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.01
+        "seconds": 1.657
       },
       "needle-05": {
         "cjk": false,
@@ -954,7 +954,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.999
+        "seconds": 1.617
       },
       "needle-06": {
         "cjk": false,
@@ -962,7 +962,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.018
+        "seconds": 1.624
       },
       "needle-07": {
         "cjk": false,
@@ -970,7 +970,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.017
+        "seconds": 1.614
       },
       "needle-08": {
         "cjk": false,
@@ -978,7 +978,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.096
+        "seconds": 1.634
       },
       "needle-09": {
         "cjk": false,
@@ -986,7 +986,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.989
+        "seconds": 1.656
       },
       "needle-10": {
         "cjk": true,
@@ -994,7 +994,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.9502344167898356,
-        "seconds": 12.163
+        "seconds": 11.562
       },
       "needle-11": {
         "cjk": true,
@@ -1002,7 +1002,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 12.173
+        "seconds": 11.577
       },
       "needle-12": {
         "cjk": true,
@@ -1010,7 +1010,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.176
+        "seconds": 11.602
       },
       "needle-13": {
         "cjk": true,
@@ -1018,7 +1018,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.137
+        "seconds": 11.585
       },
       "needle-14": {
         "cjk": true,
@@ -1026,7 +1026,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 12.148
+        "seconds": 11.542
       },
       "spread-01": {
         "cjk": false,
@@ -1034,7 +1034,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3101303130676284,
-        "seconds": 0.981
+        "seconds": 1.649
       },
       "spread-02": {
         "cjk": false,
@@ -1042,7 +1042,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.988
+        "seconds": 1.647
       },
       "spread-03": {
         "cjk": false,
@@ -1050,7 +1050,7 @@
         "doc_ndcg": 0.16771752171325524,
         "dochit3": 0,
         "ndcg": 0.16771752171325524,
-        "seconds": 0.984
+        "seconds": 1.634
       },
       "spread-04": {
         "cjk": false,
@@ -1058,7 +1058,7 @@
         "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.2640681225725909,
-        "seconds": 0.968
+        "seconds": 1.605
       },
       "spread-05": {
         "cjk": false,
@@ -1066,7 +1066,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.985
+        "seconds": 1.626
       },
       "spread-06": {
         "cjk": false,
@@ -1074,7 +1074,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.984
+        "seconds": 1.683
       },
       "spread-07": {
         "cjk": false,
@@ -1082,7 +1082,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.015
+        "seconds": 1.704
       },
       "spread-08": {
         "cjk": false,
@@ -1090,7 +1090,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.011
+        "seconds": 1.674
       },
       "spread-09": {
         "cjk": false,
@@ -1098,7 +1098,7 @@
         "doc_ndcg": 0.5307212739772434,
         "dochit3": 1,
         "ndcg": 0.39106560501896365,
-        "seconds": 0.98
+        "seconds": 1.616
       },
       "spread-10": {
         "cjk": false,
@@ -1106,7 +1106,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.987
+        "seconds": 1.65
       },
       "spread-11": {
         "cjk": false,
@@ -1114,7 +1114,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.005
+        "seconds": 1.722
       },
       "spread-12": {
         "cjk": false,
@@ -1122,7 +1122,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5802792108518124,
-        "seconds": 0.967
+        "seconds": 1.618
       },
       "spread-13": {
         "cjk": false,
@@ -1130,7 +1130,7 @@
         "doc_ndcg": 0.40460165200940457,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.974
+        "seconds": 1.637
       },
       "spread-14": {
         "cjk": false,
@@ -1138,7 +1138,7 @@
         "doc_ndcg": 0.4648536698336167,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.977
+        "seconds": 1.621
       },
       "spread-15": {
         "cjk": false,
@@ -1146,7 +1146,7 @@
         "doc_ndcg": 0.7974779478881874,
         "dochit3": 1,
         "ndcg": 0.26582598262939583,
-        "seconds": 0.975
+        "seconds": 1.599
       },
       "spread-16": {
         "cjk": false,
@@ -1154,7 +1154,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.23981246656813146,
-        "seconds": 0.961
+        "seconds": 1.669
       },
       "spread-17": {
         "cjk": false,
@@ -1162,7 +1162,7 @@
         "doc_ndcg": 0.49534603413539835,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.98
+        "seconds": 1.651
       },
       "spread-18": {
         "cjk": false,
@@ -1170,7 +1170,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.988
+        "seconds": 1.63
       },
       "spread-19": {
         "cjk": false,
@@ -1178,7 +1178,7 @@
         "doc_ndcg": 0.22883924989280793,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.976
+        "seconds": 1.617
       },
       "spread-20": {
         "cjk": false,
@@ -1186,7 +1186,7 @@
         "doc_ndcg": 0.21974347732050664,
         "dochit3": 0,
         "ndcg": 0.21974347732050664,
-        "seconds": 1.004
+        "seconds": 1.662
       },
       "spread-21": {
         "cjk": false,
@@ -1194,7 +1194,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.41183384043543503,
-        "seconds": 0.968
+        "seconds": 1.61
       },
       "spread-22": {
         "cjk": false,
@@ -1202,7 +1202,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.982
+        "seconds": 1.668
       },
       "spread-23": {
         "cjk": false,
@@ -1210,7 +1210,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.988
+        "seconds": 1.632
       },
       "spread-24": {
         "cjk": false,
@@ -1218,7 +1218,7 @@
         "doc_ndcg": 0.4796249331362629,
         "dochit3": 1,
         "ndcg": 0.4796249331362629,
-        "seconds": 0.983
+        "seconds": 1.616
       },
       "spread-25": {
         "cjk": false,
@@ -1226,7 +1226,7 @@
         "doc_ndcg": 0.2940806813328203,
         "dochit3": 0,
         "ndcg": 0.2940806813328203,
-        "seconds": 0.981
+        "seconds": 1.625
       },
       "trap-01": {
         "cjk": false,
@@ -1234,7 +1234,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.983
+        "seconds": 1.667
       },
       "trap-02": {
         "cjk": false,
@@ -1242,7 +1242,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.961
+        "seconds": 1.619
       },
       "trap-03": {
         "cjk": false,
@@ -1250,7 +1250,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.985
+        "seconds": 1.633
       },
       "trap-04": {
         "cjk": false,
@@ -1258,7 +1258,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.963
+        "seconds": 1.602
       },
       "trap-05": {
         "cjk": false,
@@ -1266,7 +1266,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.952
+        "seconds": 1.596
       },
       "trap-06": {
         "cjk": false,
@@ -1274,7 +1274,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.98
+        "seconds": 1.659
       },
       "trap-07": {
         "cjk": false,
@@ -1282,7 +1282,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 2.216
+        "seconds": 3.716
       },
       "trap-08": {
         "cjk": false,
@@ -1290,7 +1290,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.96
+        "seconds": 1.598
       },
       "trap-09": {
         "cjk": false,
@@ -1298,7 +1298,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.723
+        "seconds": 3.053
       },
       "trap-10": {
         "cjk": false,
@@ -1306,7 +1306,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.959
+        "seconds": 1.643
       },
       "trap-11": {
         "cjk": false,
@@ -1314,7 +1314,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.966
+        "seconds": 1.597
       },
       "trap-12": {
         "cjk": false,
@@ -1322,7 +1322,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 2.215
+        "seconds": 3.795
       },
       "trap-13": {
         "cjk": false,
@@ -1330,7 +1330,7 @@
         "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.43067655807339306,
-        "seconds": 0.965
+        "seconds": 1.613
       },
       "trap-14": {
         "cjk": false,
@@ -1338,7 +1338,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.976
+        "seconds": 1.663
       },
       "trap-15": {
         "cjk": false,
@@ -1346,7 +1346,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.968
+        "seconds": 1.637
       },
       "trap-16": {
         "cjk": false,
@@ -1354,7 +1354,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.957
+        "seconds": 1.598
       },
       "trap-17": {
         "cjk": false,
@@ -1362,7 +1362,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.95
+        "seconds": 1.586
       },
       "trap-18": {
         "cjk": false,
@@ -1370,7 +1370,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.996
+        "seconds": 3.452
       },
       "trap-19": {
         "cjk": false,
@@ -1378,7 +1378,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.949
+        "seconds": 1.6
       },
       "trap-20": {
         "cjk": false,
@@ -1386,7 +1386,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.961
+        "seconds": 1.599
       },
       "trap-21": {
         "cjk": false,
@@ -1394,7 +1394,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.961
+        "seconds": 1.587
       },
       "trap-22": {
         "cjk": false,
@@ -1402,7 +1402,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.964
+        "seconds": 1.597
       },
       "trap-23": {
         "cjk": false,
@@ -1410,7 +1410,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.912
+        "seconds": 3.308
       },
       "trap-24": {
         "cjk": false,
@@ -1418,7 +1418,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 2.106
+        "seconds": 3.565
       },
       "trap-25": {
         "cjk": false,
@@ -1426,7 +1426,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.952
+        "seconds": 1.598
       }
     },
     "semantic": {
@@ -1436,7 +1436,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.856
+        "seconds": 1.11
       },
       "described-02": {
         "cjk": false,
@@ -1444,7 +1444,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.877
+        "seconds": 1.116
       },
       "described-03": {
         "cjk": false,
@@ -1452,7 +1452,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.837
+        "seconds": 1.124
       },
       "described-04": {
         "cjk": false,
@@ -1460,7 +1460,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.865
+        "seconds": 1.146
       },
       "described-05": {
         "cjk": false,
@@ -1468,7 +1468,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.863
+        "seconds": 1.147
       },
       "described-06": {
         "cjk": false,
@@ -1476,7 +1476,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.843
+        "seconds": 1.128
       },
       "described-07": {
         "cjk": false,
@@ -1484,7 +1484,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.858
+        "seconds": 1.108
       },
       "described-08": {
         "cjk": false,
@@ -1492,7 +1492,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3010299956639812,
-        "seconds": 0.874
+        "seconds": 1.103
       },
       "described-09": {
         "cjk": false,
@@ -1500,7 +1500,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.893
+        "seconds": 1.111
       },
       "described-10": {
         "cjk": false,
@@ -1508,7 +1508,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.878
+        "seconds": 1.12
       },
       "described-11": {
         "cjk": false,
@@ -1516,7 +1516,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.976
+        "seconds": 1.16
       },
       "described-12": {
         "cjk": false,
@@ -1524,7 +1524,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.991
+        "seconds": 1.182
       },
       "described-13": {
         "cjk": false,
@@ -1532,7 +1532,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.927
+        "seconds": 1.149
       },
       "described-14": {
         "cjk": false,
@@ -1540,7 +1540,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.43067655807339306,
-        "seconds": 0.91
+        "seconds": 1.12
       },
       "described-15": {
         "cjk": false,
@@ -1548,7 +1548,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.993
+        "seconds": 1.116
       },
       "described-16": {
         "cjk": false,
@@ -1556,7 +1556,7 @@
         "doc_ndcg": 0.3562071871080222,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.879
+        "seconds": 1.114
       },
       "described-17": {
         "cjk": false,
@@ -1564,7 +1564,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.928
+        "seconds": 1.106
       },
       "described-18": {
         "cjk": false,
@@ -1572,7 +1572,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.875
+        "seconds": 1.14
       },
       "described-19": {
         "cjk": false,
@@ -1580,7 +1580,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.884
+        "seconds": 1.15
       },
       "described-20": {
         "cjk": false,
@@ -1588,7 +1588,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.43067655807339306,
-        "seconds": 0.893
+        "seconds": 1.142
       },
       "described-21": {
         "cjk": false,
@@ -1596,7 +1596,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.904
+        "seconds": 1.12
       },
       "described-22": {
         "cjk": false,
@@ -1604,7 +1604,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.909
+        "seconds": 1.117
       },
       "described-23": {
         "cjk": false,
@@ -1612,7 +1612,7 @@
         "doc_ndcg": 0.38685280723454163,
         "dochit3": 0,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.882
+        "seconds": 1.116
       },
       "described-24": {
         "cjk": false,
@@ -1620,7 +1620,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.9
+        "seconds": 1.118
       },
       "described-25": {
         "cjk": false,
@@ -1628,7 +1628,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.894
+        "seconds": 1.117
       },
       "needle-01": {
         "cjk": false,
@@ -1636,7 +1636,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.886
+        "seconds": 1.167
       },
       "needle-02": {
         "cjk": false,
@@ -1644,7 +1644,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.855
+        "seconds": 1.116
       },
       "needle-03": {
         "cjk": false,
@@ -1652,7 +1652,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.836
+        "seconds": 1.111
       },
       "needle-04": {
         "cjk": false,
@@ -1660,7 +1660,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.841
+        "seconds": 1.11
       },
       "needle-05": {
         "cjk": false,
@@ -1668,7 +1668,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.886
+        "seconds": 1.105
       },
       "needle-06": {
         "cjk": false,
@@ -1676,7 +1676,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.981
+        "seconds": 1.12
       },
       "needle-07": {
         "cjk": false,
@@ -1684,7 +1684,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.094
+        "seconds": 1.128
       },
       "needle-08": {
         "cjk": false,
@@ -1692,7 +1692,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.867
+        "seconds": 1.144
       },
       "needle-09": {
         "cjk": false,
@@ -1700,7 +1700,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.973
+        "seconds": 1.125
       },
       "needle-10": {
         "cjk": true,
@@ -1708,7 +1708,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.9502344167898356,
-        "seconds": 0.924
+        "seconds": 1.111
       },
       "needle-11": {
         "cjk": true,
@@ -1716,7 +1716,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.31546487678572877,
-        "seconds": 1.014
+        "seconds": 1.102
       },
       "needle-12": {
         "cjk": true,
@@ -1724,7 +1724,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.955
+        "seconds": 1.123
       },
       "needle-13": {
         "cjk": true,
@@ -1732,7 +1732,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.959
+        "seconds": 1.109
       },
       "needle-14": {
         "cjk": true,
@@ -1740,7 +1740,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 1.035
+        "seconds": 1.137
       },
       "spread-01": {
         "cjk": false,
@@ -1748,7 +1748,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.2289700384906115,
-        "seconds": 0.917
+        "seconds": 1.151
       },
       "spread-02": {
         "cjk": false,
@@ -1756,7 +1756,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.872
+        "seconds": 1.141
       },
       "spread-03": {
         "cjk": false,
@@ -1764,7 +1764,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.991
+        "seconds": 1.113
       },
       "spread-04": {
         "cjk": false,
@@ -1772,7 +1772,7 @@
         "doc_ndcg": 0.6131471927654584,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.221
+        "seconds": 1.124
       },
       "spread-05": {
         "cjk": false,
@@ -1780,7 +1780,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.933
+        "seconds": 1.117
       },
       "spread-06": {
         "cjk": false,
@@ -1788,7 +1788,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.929
+        "seconds": 1.116
       },
       "spread-07": {
         "cjk": false,
@@ -1796,7 +1796,7 @@
         "doc_ndcg": 0.38685280723454163,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 1.037
+        "seconds": 1.12
       },
       "spread-08": {
         "cjk": false,
@@ -1804,7 +1804,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.998
+        "seconds": 1.185
       },
       "spread-09": {
         "cjk": false,
@@ -1812,7 +1812,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.857
+        "seconds": 1.16
       },
       "spread-10": {
         "cjk": false,
@@ -1820,7 +1820,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.837
+        "seconds": 1.123
       },
       "spread-11": {
         "cjk": false,
@@ -1828,7 +1828,7 @@
         "doc_ndcg": 0.7784783478088368,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.885
+        "seconds": 1.147
       },
       "spread-12": {
         "cjk": false,
@@ -1836,7 +1836,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.832
+        "seconds": 1.17
       },
       "spread-13": {
         "cjk": false,
@@ -1844,7 +1844,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.855
+        "seconds": 1.125
       },
       "spread-14": {
         "cjk": false,
@@ -1852,7 +1852,7 @@
         "doc_ndcg": 0.7653606369886217,
         "dochit3": 1,
         "ndcg": 0.2960819109658652,
-        "seconds": 0.853
+        "seconds": 1.107
       },
       "spread-15": {
         "cjk": false,
@@ -1860,7 +1860,7 @@
         "doc_ndcg": 0.5316519652587917,
         "dochit3": 1,
         "ndcg": 0.18937825106528608,
-        "seconds": 0.845
+        "seconds": 1.103
       },
       "spread-16": {
         "cjk": false,
@@ -1868,7 +1868,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.4796249331362629,
-        "seconds": 0.847
+        "seconds": 1.102
       },
       "spread-17": {
         "cjk": false,
@@ -1876,7 +1876,7 @@
         "doc_ndcg": 0.7763433706236033,
         "dochit3": 1,
         "ndcg": 0.6387878864795979,
-        "seconds": 0.838
+        "seconds": 1.105
       },
       "spread-18": {
         "cjk": false,
@@ -1884,7 +1884,7 @@
         "doc_ndcg": 0.8670870086853021,
         "dochit3": 1,
         "ndcg": 0.5316519652587917,
-        "seconds": 0.838
+        "seconds": 1.133
       },
       "spread-19": {
         "cjk": false,
@@ -1892,7 +1892,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.21974347732050664,
-        "seconds": 0.828
+        "seconds": 1.156
       },
       "spread-20": {
         "cjk": false,
@@ -1900,7 +1900,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.4796249331362629,
-        "seconds": 0.834
+        "seconds": 1.151
       },
       "spread-21": {
         "cjk": false,
@@ -1908,7 +1908,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.868
+        "seconds": 1.121
       },
       "spread-22": {
         "cjk": false,
@@ -1916,7 +1916,7 @@
         "doc_ndcg": 0.38685280723454163,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.85
+        "seconds": 1.17
       },
       "spread-23": {
         "cjk": false,
@@ -1924,7 +1924,7 @@
         "doc_ndcg": 0.5316519652587917,
         "dochit3": 1,
         "ndcg": 0.5316519652587917,
-        "seconds": 0.869
+        "seconds": 1.13
       },
       "spread-24": {
         "cjk": false,
@@ -1932,7 +1932,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.85
+        "seconds": 1.111
       },
       "spread-25": {
         "cjk": false,
@@ -1940,7 +1940,7 @@
         "doc_ndcg": 0.7601875334318685,
         "dochit3": 1,
         "ndcg": 0.7601875334318685,
-        "seconds": 0.874
+        "seconds": 1.099
       },
       "trap-01": {
         "cjk": false,
@@ -1948,7 +1948,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.839
+        "seconds": 1.113
       },
       "trap-02": {
         "cjk": false,
@@ -1956,7 +1956,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.873
+        "seconds": 1.113
       },
       "trap-03": {
         "cjk": false,
@@ -1964,7 +1964,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.853
+        "seconds": 1.107
       },
       "trap-04": {
         "cjk": false,
@@ -1972,7 +1972,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.832
+        "seconds": 1.109
       },
       "trap-05": {
         "cjk": false,
@@ -1980,7 +1980,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.853
+        "seconds": 1.124
       },
       "trap-06": {
         "cjk": false,
@@ -1988,7 +1988,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.858
+        "seconds": 1.161
       },
       "trap-07": {
         "cjk": false,
@@ -1996,7 +1996,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.826
+        "seconds": 1.14
       },
       "trap-08": {
         "cjk": false,
@@ -2004,7 +2004,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.872
+        "seconds": 1.115
       },
       "trap-09": {
         "cjk": false,
@@ -2012,7 +2012,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.43067655807339306,
-        "seconds": 0.87
+        "seconds": 1.108
       },
       "trap-10": {
         "cjk": false,
@@ -2020,7 +2020,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.871
+        "seconds": 1.107
       },
       "trap-11": {
         "cjk": false,
@@ -2028,7 +2028,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.856
+        "seconds": 1.107
       },
       "trap-12": {
         "cjk": false,
@@ -2036,7 +2036,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.838
+        "seconds": 1.106
       },
       "trap-13": {
         "cjk": false,
@@ -2044,7 +2044,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 1.106
+        "seconds": 1.153
       },
       "trap-14": {
         "cjk": false,
@@ -2052,7 +2052,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.836
+        "seconds": 1.146
       },
       "trap-15": {
         "cjk": false,
@@ -2060,7 +2060,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.831
+        "seconds": 1.127
       },
       "trap-16": {
         "cjk": false,
@@ -2068,7 +2068,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.839
+        "seconds": 1.108
       },
       "trap-17": {
         "cjk": false,
@@ -2076,7 +2076,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.917
+        "seconds": 1.111
       },
       "trap-18": {
         "cjk": false,
@@ -2084,7 +2084,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.832
+        "seconds": 1.102
       },
       "trap-19": {
         "cjk": false,
@@ -2092,7 +2092,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.83
+        "seconds": 1.107
       },
       "trap-20": {
         "cjk": false,
@@ -2100,7 +2100,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.851
+        "seconds": 1.118
       },
       "trap-21": {
         "cjk": false,
@@ -2108,7 +2108,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.827
+        "seconds": 1.12
       },
       "trap-22": {
         "cjk": false,
@@ -2116,7 +2116,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.844
+        "seconds": 1.143
       },
       "trap-23": {
         "cjk": false,
@@ -2124,7 +2124,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.854
+        "seconds": 1.125
       },
       "trap-24": {
         "cjk": false,
@@ -2132,7 +2132,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.851
+        "seconds": 1.104
       },
       "trap-25": {
         "cjk": false,
@@ -2140,7 +2140,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.839
+        "seconds": 1.105
       }
     }
   },
@@ -2150,28 +2150,28 @@
     "auto": {
       "by_class": {
         "described": {
-          "doc_ndcg": 0.6097,
-          "dochit3": 0.48,
+          "doc_ndcg": 0.5872,
+          "dochit3": 0.68,
           "n": 25,
-          "ndcg": 0.1569
+          "ndcg": 0.1461
         },
         "needle": {
           "doc_ndcg": 1.0,
           "dochit3": 1.0,
           "n": 14,
-          "ndcg": 0.9607
+          "ndcg": 0.9344
         },
         "spread": {
-          "doc_ndcg": 0.5084,
-          "dochit3": 0.64,
+          "doc_ndcg": 0.5427,
+          "dochit3": 0.72,
           "n": 25,
-          "ndcg": 0.2599
+          "ndcg": 0.2701
         },
         "trap": {
           "doc_ndcg": 0.9852,
           "dochit3": 1.0,
           "n": 25,
-          "ndcg": 0.7537
+          "ndcg": 0.6764
         }
       },
       "cjk_subset": {
@@ -2180,18 +2180,18 @@
         "n": 5,
         "ndcg": 0.89
       },
-      "mean_query_seconds": 2.149,
+      "mean_query_seconds": 3.021,
       "non_cjk": {
-        "doc_ndcg": 0.7331,
-        "dochit3": 0.7381,
+        "doc_ndcg": 0.7366,
+        "dochit3": 0.8214,
         "n": 84,
-        "ndcg": 0.4555
+        "ndcg": 0.4279
       },
       "overall": {
-        "doc_ndcg": 0.7481,
-        "dochit3": 0.7528,
+        "doc_ndcg": 0.7514,
+        "dochit3": 0.8315,
         "n": 89,
-        "ndcg": 0.4799
+        "ndcg": 0.4539
       },
       "search_mode_reported": [
         "hybrid"
@@ -2230,7 +2230,7 @@
         "n": 5,
         "ndcg": 0.9162
       },
-      "mean_query_seconds": 2.084,
+      "mean_query_seconds": 3.021,
       "non_cjk": {
         "doc_ndcg": 0.5299,
         "dochit3": 0.5476,
@@ -2280,7 +2280,7 @@
         "n": 5,
         "ndcg": 0.5244
       },
-      "mean_query_seconds": 0.892,
+      "mean_query_seconds": 1.125,
       "non_cjk": {
         "doc_ndcg": 0.7255,
         "dochit3": 0.75,

--- a/benchmark_data/corpus_search/modes_results_500.md
+++ b/benchmark_data/corpus_search/modes_results_500.md
@@ -28,62 +28,33 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 | semantic | 0.524 | 0.437 |
 | auto | 0.890 | 0.428 |
 
-Sanity cross-check: compare keyword overall against the stage-2 arm-B reference (~0.547) only on the 64 non-`described` queries. The 89-query overall includes `described`, where keyword scores ~0.13, so it lands well below the reference on query mix alone. Interpretation is appended by hand after the run.
-## Interpretation (89-query run; cite the tables above, not this prose)
+## Interpretation (500-doc run, document arm live; cite the tables above, not this prose)
 
-Hybrid is the strongest mode on every cut: page NDCG@10 0.541,
-doc-NDCG@10 0.838, doc-hit@3 0.899, needle 0.996. The arms complement as
-designed: semantic is near-immune to lexical traps (0.785 vs keyword's
-0.596) and keyword anchors literal precision (needle 0.968). Every mode
-runs in under half a second per query on a warmed 100-doc corpus.
+Hybrid is the strongest mode on every page-level cut: overall NDCG@10
+0.454, described 0.146, needle 0.934, trap 0.676, at 3.02 s/query over
+a warmed 500-doc corpus (100 graded arXiv papers plus 400 distractors).
+At the doc level it also leads: overall 0.751, described 0.587, needle
+1.000, trap 0.985.
 
-`described` is the binding constraint, not corpus size. Every mode scores
-0.24 or below on it (hybrid 0.241, keyword 0.134) and it is a quarter of
-the query set, so it sets the page-level overall almost by itself.
-Doc-level holds at 0.838, which is the label-sparsity gap the doc-level
-table exists to separate: the right document is being found, the graded
-page inside it often is not.
+**The document arm's effect, isolated.** Against the Aug-24 pre-arm
+500-doc run preserved at commit `2119f57` (described doc-hit@3 0.480,
+spread 0.640, needle 1.000, trap 0.985), this post-arm run reads
+described doc-hit@3 0.680 (+0.20, 12/25 -> 17/25) and spread doc-hit@3
+0.720 (+0.08, 16/25 -> 18/25), with needle and trap unchanged at 1.000.
+`described` and `spread` are the classes with real distractor pressure
+at 500 docs; needle and trap stay pinned near 1.000 regardless of
+corpus size because they are lexically distinctive or unambiguous by
+construction.
 
-### Do not cite 0.674 / doc-hit@3 1.000
-
-Those are the superseded 64-query run (commit `040df8b`), not comparable
-to the tables above. The 25 `described` queries were added afterwards and
-are the weakest class for every mode, so the overall mean drops on query
-mix alone. Two keyword-arm fixes also landed in between: the OR-joined
-retry (`2820061`) and term-coverage ranking (`086c84e`).
-
-Held to the same 64 non-`described` queries, this run against that one:
-
-| mode | overall NDCG@10 | doc-hit@3 |
-|---|---|---|
-| keyword | 0.547 -> 0.586 (+0.039) | 0.859 -> 0.953 |
-| semantic | 0.579 -> 0.579 (unchanged) | 0.875 -> 0.875 |
-| auto | 0.674 -> 0.658 (-0.016) | 1.000 -> 0.969 |
-
-Two cells carry all of it. Keyword `trap` 0.476 -> 0.596 with doc-hit@3
-0.72 -> 0.96: term-coverage ranking working as designed, traps were being
-won on file order. Hybrid `spread` 0.392 -> 0.350 with doc-hit@3
-1.000 -> 0.92: two of 25 spread queries lost their gold document from the
-top three, and that is the whole of the lost 1.000. Semantic is identical
-across every class, the expected control for two keyword-arm changes.
-
-Working hypothesis, unverified: rarity-weighted coverage concentrates
-rank mass on fewer documents, which is right for `trap` and wrong for
-`spread`, where gold is deliberately scattered. Two queries is inside
-noise, so this is recorded rather than acted on; revisit if a second
-corpus reproduces it.
-
-### Sanity cross-check
-
-The stage-2 arm-B reference (~0.547) was matched by the 64-query run's
-keyword overall. It is not comparable to the 89-query keyword overall
-(0.459), which includes `described` at 0.134. On the 64-query subset this
-run's keyword overall is 0.586, above the reference, as expected after
-the two keyword fixes.
-
-History: the pre-fix CJK record and that bug's narrative are in this
-file's git history (commit `07cbff2`); the 64-query numbers are in
-`040df8b`.
+**The control that makes this a real effect, not corpus noise.** The
+keyword and semantic arms' per-class doc-hit@3 are identical, query for
+query, between the Aug-24 pre-arm run and this one: keyword described
+0.20, needle 1.000, spread 0.36, trap 0.92 (both runs); semantic
+described 0.48, needle 0.929, spread 0.68, trap 1.000 (both runs).
+Neither arm's code changed on this branch, so an unchanged score is
+exactly what should happen; only hybrid moved, and only on the classes
+the document arm targets. See "Task 8 gate results" below for the full
+per-class doc-hit@3 and doc-NDCG@10 table.
 
 ## Task 8 gate results: document arm at 500 docs (2026-08-29, this machine, this branch)
 
@@ -186,5 +157,12 @@ grepping it for `doc_profile_coverage` is not a usable pre/post signal
 `scripts/benchmark_excerpt_quality.py`: exit=0, GATE VERDICT PASS.
 excerpt_containment=0.800, bbox_containment=0.800, 0 regressions, 0 stale
 known_fail rows.
+
+### Single-doc arm not re-run
+
+This benchmark's `--single-doc-arm` flag was not passed on this pass, so
+no single-doc `pdf_search` figures were regenerated here. The
+previously published single-doc numbers stand: `pdf_search` is untouched
+by the document-arm work on this branch.
 
 ### Overall verdict: all Task 8 gates PASS.

--- a/benchmark_data/corpus_search/modes_results_500.md
+++ b/benchmark_data/corpus_search/modes_results_500.md
@@ -4,9 +4,9 @@ Corpus: 500 docs. Queries: 89 (graded ground truth, stage-2). top_k=10. The tool
 
 | mode | overall NDCG@10 | described | needle | spread | trap | doc-hit@3 | s/query |
 |---|---|---|---|---|---|---|---|
-| keyword (keyword) | 0.351 | 0.064 | 0.944 | 0.145 | 0.513 | 0.573 | 2.08 |
-| semantic (semantic) | 0.442 | 0.157 | 0.751 | 0.220 | 0.777 | 0.753 | 0.89 |
-| auto (hybrid) | 0.480 | 0.157 | 0.961 | 0.260 | 0.754 | 0.753 | 2.15 |
+| keyword (keyword) | 0.351 | 0.064 | 0.944 | 0.145 | 0.513 | 0.573 | 3.02 |
+| semantic (semantic) | 0.442 | 0.157 | 0.751 | 0.220 | 0.777 | 0.753 | 1.12 |
+| auto (hybrid) | 0.454 | 0.146 | 0.934 | 0.270 | 0.676 | 0.832 | 3.02 |
 
 ## Doc-level NDCG@10 (ranked docs deduped, gain = doc's best label)
 
@@ -16,7 +16,7 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 |---|---|---|---|---|---|
 | keyword | 0.556 | 0.169 | 1.000 | 0.378 | 0.873 |
 | semantic | 0.735 | 0.610 | 0.938 | 0.497 | 0.985 |
-| auto | 0.748 | 0.610 | 1.000 | 0.508 | 0.985 |
+| auto | 0.751 | 0.587 | 1.000 | 0.543 | 0.985 |
 
 ## CJK subset (5 needle queries on Japanese docs; embedding model is English bge-small, so the semantic arm is expected to be weak there)
 
@@ -24,84 +24,165 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 |---|---|---|
 | keyword | 0.916 | 0.318 |
 | semantic | 0.524 | 0.437 |
-| auto | 0.890 | 0.456 |
+| auto | 0.890 | 0.428 |
 
 Sanity cross-check: compare keyword overall against the stage-2 arm-B reference (~0.547) only on the 64 non-`described` queries. The 89-query overall includes `described`, where keyword scores ~0.13, so it lands well below the reference on query mix alone. Interpretation is appended by hand after the run.
+## Interpretation (89-query run; cite the tables above, not this prose)
 
-## Stage 0 verdict (500-doc rung: 100 gold + 400 arXiv distractors)
+Hybrid is the strongest mode on every cut: page NDCG@10 0.541,
+doc-NDCG@10 0.838, doc-hit@3 0.899, needle 0.996. The arms complement as
+designed: semantic is near-immune to lexical traps (0.785 vs keyword's
+0.596) and keyword anchors literal precision (needle 0.968). Every mode
+runs in under half a second per query on a warmed 100-doc corpus.
 
-**Decision: HOLD the cap raise.** The described-query routing gate fails under
-5x distractor pressure. Per the scale-1k design's pre-agreed fallback, do NOT
-raise `CORPUS_MAX_FILES`; open the doc-level-embeddings routing investigation.
+`described` is the binding constraint, not corpus size. Every mode scores
+0.24 or below on it (hybrid 0.241, keyword 0.134) and it is a quarter of
+the query set, so it sets the page-level overall almost by itself.
+Doc-level holds at 0.838, which is the label-sparsity gap the doc-level
+table exists to separate: the right document is being found, the graded
+page inside it often is not.
 
-The 900-doc (1,000-total) rung was deliberately NOT run: the rung was staged
-at 500 specifically so a described-gate failure stops the work before the full
-download. It did.
+### Do not cite 0.674 / doc-hit@3 1.000
 
-### Ship gates (hybrid/auto is the production default; baseline = committed 100-doc run)
+Those are the superseded 64-query run (commit `040df8b`), not comparable
+to the tables above. The 25 `described` queries were added afterwards and
+are the weakest class for every mode, so the overall mean drops on query
+mix alone. Two keyword-arm fixes also landed in between: the OR-joined
+retry (`2820061`) and term-coverage ranking (`086c84e`).
 
-| gate | 100-doc baseline | 500-doc rung | verdict |
+Held to the same 64 non-`described` queries, this run against that one:
+
+| mode | overall NDCG@10 | doc-hit@3 |
+|---|---|---|
+| keyword | 0.547 -> 0.586 (+0.039) | 0.859 -> 0.953 |
+| semantic | 0.579 -> 0.579 (unchanged) | 0.875 -> 0.875 |
+| auto | 0.674 -> 0.658 (-0.016) | 1.000 -> 0.969 |
+
+Two cells carry all of it. Keyword `trap` 0.476 -> 0.596 with doc-hit@3
+0.72 -> 0.96: term-coverage ranking working as designed, traps were being
+won on file order. Hybrid `spread` 0.392 -> 0.350 with doc-hit@3
+1.000 -> 0.92: two of 25 spread queries lost their gold document from the
+top three, and that is the whole of the lost 1.000. Semantic is identical
+across every class, the expected control for two keyword-arm changes.
+
+Working hypothesis, unverified: rarity-weighted coverage concentrates
+rank mass on fewer documents, which is right for `trap` and wrong for
+`spread`, where gold is deliberately scattered. Two queries is inside
+noise, so this is recorded rather than acted on; revisit if a second
+corpus reproduces it.
+
+### Sanity cross-check
+
+The stage-2 arm-B reference (~0.547) was matched by the 64-query run's
+keyword overall. It is not comparable to the 89-query keyword overall
+(0.459), which includes `described` at 0.134. On the 64-query subset this
+run's keyword overall is 0.586, above the reference, as expected after
+the two keyword fixes.
+
+History: the pre-fix CJK record and that bug's narrative are in this
+file's git history (commit `07cbff2`); the 64-query numbers are in
+`040df8b`.
+
+## Task 8 gate results: document arm at 500 docs (2026-08-29, this machine, this branch)
+
+Auto (hybrid) mode, 500 docs (100 gold + 400 distractors), 89 graded queries,
+document-arm feature at `feat/doc-profile-routing` (1c2caf1..2119f57), against
+the Aug-24 pre-arm 500-doc numbers in this same file's prior committed
+version (described 0.48, spread 0.64, needle 1.000, trap 0.985, ~2.15 s/query).
+
+| class | pre-arm doc-hit@3 (Aug-24) | post-arm doc-hit@3 | doc-NDCG@10 | gate | verdict |
+|---|---|---|---|---|---|
+| described | 0.480 | 0.680 (17/25) | 0.587 | >= 0.60 | PASS |
+| spread | 0.640 | 0.720 (18/25) | 0.543 | (informational) | n/a |
+| needle | 1.000 | 1.000 (14/14) | 1.000 | >= 0.98 | PASS |
+| trap | 0.985 | 1.000 (25/25) | 0.985 | >= 0.98 | PASS |
+
+s/query (auto): 3.021, gate <= 5. PASS.
+
+`CORPUS_MAX_FILES` stays 100. This 500-doc rung is a benchmark-only
+distractor-manifest workaround (`--distractor-manifest` / `--max-docs`); it
+does not raise the cap in the shipped tool. Raising the cap is a separate,
+unstarted stage-1 item.
+
+### Latency: the arm adds microseconds, not the run-to-run swing
+
+Within the SAME run, auto (hybrid) mean seconds/query equals keyword mean
+seconds/query to four decimal places at every corpus size measured:
+
+| corpus | keyword s/query | auto s/query | delta |
 |---|---|---|---|
-| needle doc-NDCG ~1.0 (>=0.98) | 1.000 | 1.000 | PASS |
-| trap doc-NDCG ~1.0 (>=0.98) | 1.000 | 0.985 | PASS |
-| **described doc-hit@3 >= 0.60** | **0.720** | **0.480** | **FAIL** |
-| hybrid latency <= 5s/query | 0.41s | 2.15s | PASS |
-| permutation invariance | unit 9/9 pass | arm-A control flat | PASS |
+| 100 docs | 0.5687 | 0.5688 | +0.0001 |
+| 500 docs | 3.021 | 3.021 | ~0 |
+| 10-K (24 docs) | 0.426 | 0.414 | -0.012 (noise) |
 
-Cite per-class numbers, never the aggregate (measurement-trap rule). All
-metrics are deterministic; no LLM judge ran, so no noise floor applies.
+That confirms the doc arm itself costs microseconds, as the spec expects.
+The 100-doc run's absolute latency (0.569 s/query, all three modes) is
+higher than the Task 0 scratch baseline (0.39 s/query, auto only), but
+semantic-only mode (which the doc arm never touches) rose by the same
+proportion (0.143 -> 0.235 s/query), so the swing is ambient machine load
+on this run, not a code-path regression.
 
-### What moved, per class (doc-hit@3, hybrid)
+### Permutation invariance (`scripts/recheck_tiebreak_permutation.py`, 500 docs, seeds 1-6)
 
-| class | 100 | 500 | delta |
-|---|---|---|---|
-| needle | 1.000 | 1.000 | 0 |
-| trap | 1.000 | 1.000 | 0 |
-| spread | 0.920 | 0.640 | -0.280 |
-| described | 0.720 | 0.480 | -0.240 |
+```
+     run   needle   spread     trap  OVERALL
+--------------------------------------------
+   arm A    0.944    0.291    0.503    0.517
+   arm B    0.944    0.351    0.430    0.512   <- real filenames (published)
+  perm 1    0.944    0.116    0.403    0.409
+  perm 2    0.944    0.174    0.379    0.422
+  perm 3    0.944    0.153    0.368    0.410
+  perm 4    0.944    0.175    0.368    0.418
+  perm 5    0.944    0.151    0.376    0.412
+  perm 6    0.944    0.164    0.382    0.420
 
-needle and trap (literal-anchor queries) are immune to distractor pressure.
-The collapse is entirely in `described` (paraphrase) and `spread` (scattered
-gold), the classes that lean on semantic routing, which dilutes as distractors
-crowd the embedding space. The keyword arm degrades further on its own
-(described doc-hit@3 0.52 -> 0.20, trap doc-NDCG 0.960 -> 0.873); hybrid's
-semantic arm cushions it, which is why hybrid trap doc-NDCG holds at 0.985.
+needle   real is inside the permuted range
+spread   real is OUTSIDE the permuted range  ** ARM ORDER FLIPS **
+trap     real is OUTSIDE the permuted range
+OVERALL  real is OUTSIDE the permuted range
+```
 
-### Latency
+Arm A (the corpus-wide-index control) is fixed across every seed: it does
+not move, as the script's own docstring requires ("if arm A ever moves
+under permutation, this script is broken, not the benchmark"). That is the
+invariance check this script exists to certify, and it passes.
 
-Hybrid 0.41s -> 2.15s/query (keyword 0.40 -> 2.08, semantic 0.18 -> 0.89),
-roughly linear in corpus size and far under the 5s gate. The 0.41s baseline
-is this run's fresh 100-doc parity re-run; the committed `modes_results.md`
-records 0.47s from the Aug-23 baseline. Both pass the gate; the small delta
-is run-to-run timing, not a regression. Latency was never the
-constraint; retrieval quality is. This is consistent with the design's
-"described is the binding constraint, not corpus size."
+Arm B here reimplements the pre-fix stage-2 spike design (RRF fusion of
+per-document rank lists, tie-broken by `(doc_path, page)` with no relevance
+score) via `_corpus_ranking.rrf_fuse_doc_rankings` called without `scores`.
+It is not the code path this branch ships: the production
+`rrf_fuse_doc_rankings` in `src/pdf_mcp/corpus.py` accepts a `scores`
+argument specifically to replace this alphabetical tie-break with BM25
+relevance (the fix for the cross-doc tie-break defect closed earlier), and
+every corpus-search caller in `server.py` passes it. Arm B's filename
+sensitivity here reproduces the already-documented, already-closed defect
+in the retired design, not a property of anything this branch touches.
+This script does not import or exercise the document-arm code at all.
 
-### Permutation invariance
+### Held-out 10-K corpus (`benchmark_data/financial_reports`, 24 filings, 66 queries)
 
-Production cross-document ranking invariance is unit-tested at the fusion level
-(`tests/test_corpus.py::test_ranking_is_invariant_under_document_renaming` and
-`::test_equal_scores_still_break_deterministically`): renaming never reorders
-results except at exact score ties, which break deterministically by
-`(doc_path, page)`. Those pass unchanged (9/9). The rename-based recheck
-(`recheck_tiebreak_permutation.py --distractor-manifest ...`, 6 seeds, 500 docs)
-holds its arm-A control flat, confirming the harness and corpus are uncorrupted
-with distractors folded in.
+Same-day pre-arm baseline via `git checkout 7ef552f -- src/` (develop,
+pre-arm), auto mode, vs. post-arm on this branch:
 
-Caveat worth recording: that recheck tests the stage-2 SPIKE arm B (raw RRF,
-pure `(doc_path, page)` tie-break), whose "OUTSIDE the permuted range" result
-for spread/trap is pre-existing and is exactly the filename sensitivity the
-production `term-coverage x IDF` tie-break fix removed. At 500 docs that spike
-sensitivity grows (arm B real 0.512 vs permuted mean 0.415 overall), because
-distractor filenames correlate with anti-relevance (gold = low 2007-era arXiv
-IDs, sorted first; distractors = newer high IDs). The production tool neutralizes
-this via term-coverage; where it cannot (exact ties), gold sorting first would
-if anything flatter the measured described score, so the true described
-doc-hit@3 is <= 0.48. That makes the FAIL more decisive, not less.
+| class | pre-arm doc-hit@3 | post-arm doc-hit@3 | regression | gate |
+|---|---|---|---|---|
+| concept (n=10) | 0.500 (5/10) | 0.600 (6/10) | improved | PASS |
+| needle (n=25) | 0.880 (22/25) | 0.920 (23/25) | improved | PASS |
+| route (n=21) | 0.952 (20/21) | 0.952 (20/21) | unchanged | PASS |
+| trap (n=10) | 0.700 (7/10) | 0.600 (6/10) | -1 query | PASS (<= 1 query) |
 
-### Corpus
+Sanity check on the pre/post split: `pdf_corpus_search(..., mode="auto")`
+returns a `doc_profile_coverage` key only with post-arm `src/` (confirmed
+`True` post-arm, `False` pre-arm on the same manifest paths); the harness's
+own `modes_results.json` does not persist the raw per-query response, so
+grepping it for `doc_profile_coverage` is not a usable pre/post signal
+(both print 0) and this key check was done directly against
+`pdf_corpus_search` instead.
 
-Gold: the existing 100-doc READoc-arXiv set, 89 graded queries, untouched.
-Distractors: 400 arXiv PDFs (newest submissions across cs.LG/cs.CL/cs.CV/
-math.PR/physics.data-an), deduped against gold by base id and title, 0 overlap,
-recorded in `distractor_manifest.json` (ids + sha256; PDFs not committed).
+### Excerpt gate
+
+`scripts/benchmark_excerpt_quality.py`: exit=0, GATE VERDICT PASS.
+excerpt_containment=0.800, bbox_containment=0.800, 0 regressions, 0 stale
+known_fail rows.
+
+### Overall verdict: all Task 8 gates PASS.

--- a/benchmark_data/corpus_search/modes_results_500.md
+++ b/benchmark_data/corpus_search/modes_results_500.md
@@ -166,3 +166,5 @@ previously published single-doc numbers stand: `pdf_search` is untouched
 by the document-arm work on this branch.
 
 ### Overall verdict: all Task 8 gates PASS.
+
+Size dependence of the document arm (50 to 500 documents, same cache, control vs arm): `doc_arm_size_sweep.md`.

--- a/benchmark_data/corpus_search/modes_results_500.md
+++ b/benchmark_data/corpus_search/modes_results_500.md
@@ -2,6 +2,8 @@
 
 Corpus: 500 docs. Queries: 89 (graded ground truth, stage-2). top_k=10. The tool itself is called per query on a warmed isolated cache, so numbers measure the agent-facing contract end to end.
 
+The Aug-24 pre-arm run (Stage 0 verdict: cap raise HELD at described doc-hit@3 0.48) is preserved in git at commit 2119f57.
+
 | mode | overall NDCG@10 | described | needle | spread | trap | doc-hit@3 | s/query |
 |---|---|---|---|---|---|---|---|
 | keyword (keyword) | 0.351 | 0.064 | 0.944 | 0.145 | 0.513 | 0.573 | 3.02 |

--- a/benchmark_data/financial_reports/modes_results.json
+++ b/benchmark_data/financial_reports/modes_results.json
@@ -8,7 +8,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.226
+        "seconds": 0.425
       },
       "concept-02": {
         "cjk": false,
@@ -16,537 +16,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.223
-      },
-      "concept-03": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.3562071871080222,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.238
-      },
-      "concept-04": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.225
-      },
-      "concept-05": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.221
-      },
-      "concept-06": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.238
-      },
-      "concept-07": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.43067655807339306,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.221
-      },
-      "concept-08": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.24
-      },
-      "concept-09": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.223
-      },
-      "concept-10": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.234
-      },
-      "needle-01": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.221
-      },
-      "needle-02": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.218
-      },
-      "needle-03": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.219
-      },
-      "needle-04": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.219
-      },
-      "needle-05": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.219
-      },
-      "needle-06": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.222
-      },
-      "needle-07": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.215
-      },
-      "needle-08": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.231
-      },
-      "needle-09": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.217
-      },
-      "needle-10": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.226
-      },
-      "needle-11": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.2890648263178879,
-        "seconds": 0.221
-      },
-      "needle-12": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.22
-      },
-      "needle-13": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.215
-      },
-      "needle-14": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.219
-      },
-      "needle-15": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.218
-      },
-      "needle-16": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.217
-      },
-      "needle-17": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.23
-      },
-      "needle-18": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.216
-      },
-      "needle-19": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.22
-      },
-      "needle-20": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.217
-      },
-      "needle-21": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.233
-      },
-      "needle-22": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.234
-      },
-      "needle-23": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.236
-      },
-      "needle-24": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.22
-      },
-      "needle-25": {
-        "cjk": false,
-        "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.218
-      },
-      "route-01": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8403030283801005,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.22
-      },
-      "route-02": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.218
-      },
-      "route-03": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.216
-      },
-      "route-04": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.219
-      },
-      "route-05": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.217
-      },
-      "route-06": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.219
-      },
-      "route-07": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8403030283801005,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.225
-      },
-      "route-08": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.219
-      },
-      "route-09": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.217
-      },
-      "route-10": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.222
-      },
-      "route-11": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.225
-      },
-      "route-12": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.9778585125241057,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.224
-      },
-      "route-13": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.215
-      },
-      "route-14": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.216
-      },
-      "route-15": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 0,
-        "ndcg": null,
-        "seconds": 0.216
-      },
-      "route-16": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 0,
-        "ndcg": null,
-        "seconds": 0.218
-      },
-      "route-17": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.216
-      },
-      "route-18": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.218
-      },
-      "route-19": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8403030283801005,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.227
-      },
-      "route-20": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.9778585125241057,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.24
-      },
-      "route-21": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.9360403422435027,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.239
-      },
-      "trap-01": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.221
-      },
-      "trap-02": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.23
-      },
-      "trap-03": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.218
-      },
-      "trap-04": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.221
-      },
-      "trap-05": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.221
-      },
-      "trap-06": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.239
-      },
-      "trap-07": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.31546487678572877,
-        "seconds": 0.217
-      },
-      "trap-08": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.22
-      },
-      "trap-09": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 0.5,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.222
-      },
-      "trap-10": {
-        "cjk": false,
-        "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.233
-      }
-    },
-    "keyword": {
-      "concept-01": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.5,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.429
-      },
-      "concept-02": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.41
+        "seconds": 0.411
       },
       "concept-03": {
         "cjk": false,
@@ -554,57 +24,9 @@
         "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.415
+        "seconds": 0.433
       },
       "concept-04": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.405
-      },
-      "concept-05": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.407
-      },
-      "concept-06": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.379
-      },
-      "concept-07": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.177
-      },
-      "concept-08": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.3010299956639812,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.412
-      },
-      "concept-09": {
-        "cjk": false,
-        "class": "concept",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.426
-      },
-      "concept-10": {
         "cjk": false,
         "class": "concept",
         "doc_ndcg": 0.0,
@@ -612,53 +34,101 @@
         "ndcg": 0.0,
         "seconds": 0.424
       },
+      "concept-05": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.31546487678572877,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.408
+      },
+      "concept-06": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.428
+      },
+      "concept-07": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.403
+      },
+      "concept-08": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.425
+      },
+      "concept-09": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.4
+      },
+      "concept-10": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.438
+      },
       "needle-01": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.23
+        "ndcg": 0.5,
+        "seconds": 0.414
       },
       "needle-02": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.179
+        "ndcg": 0.3333333333333333,
+        "seconds": 0.405
       },
       "needle-03": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.178
+        "ndcg": 1.0,
+        "seconds": 0.408
       },
       "needle-04": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.455
+        "ndcg": 1.0,
+        "seconds": 0.402
       },
       "needle-05": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.5,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.19
+        "ndcg": 0.0,
+        "seconds": 0.427
       },
       "needle-06": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.171
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.408
       },
       "needle-07": {
         "cjk": false,
@@ -666,55 +136,55 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.179
+        "seconds": 0.398
       },
       "needle-08": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.418
+        "seconds": 0.401
       },
       "needle-09": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.198
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.407
       },
       "needle-10": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.258
+        "ndcg": 0.0,
+        "seconds": 0.422
       },
       "needle-11": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.26
+        "ndcg": 0.3010299956639812,
+        "seconds": 0.465
       },
       "needle-12": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.205
+        "seconds": 0.464
       },
       "needle-13": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.5,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.206
+        "seconds": 0.403
       },
       "needle-14": {
         "cjk": false,
@@ -722,119 +192,119 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.216
+        "seconds": 0.418
       },
       "needle-15": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.412
+        "seconds": 0.4
       },
       "needle-16": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.5,
-        "dochit3": 1,
-        "ndcg": 0.5,
-        "seconds": 0.181
+        "doc_ndcg": 0.3010299956639812,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.406
       },
       "needle-17": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.5,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.204
+        "ndcg": 0.0,
+        "seconds": 0.424
       },
       "needle-18": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
-        "ndcg": 0.0,
-        "seconds": 0.402
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.405
       },
       "needle-19": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.202
+        "ndcg": 1.0,
+        "seconds": 0.412
       },
       "needle-20": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.217
+        "ndcg": 1.0,
+        "seconds": 0.398
       },
       "needle-21": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 0.38685280723454163,
-        "seconds": 0.255
+        "ndcg": 0.2890648263178879,
+        "seconds": 0.416
       },
       "needle-22": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.209
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.415
       },
       "needle-23": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.219
+        "ndcg": 0.31546487678572877,
+        "seconds": 0.408
       },
       "needle-24": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.0,
-        "dochit3": 0,
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.416
+        "seconds": 0.43
       },
       "needle-25": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.185
+        "seconds": 0.407
       },
       "route-01": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8821211986607034,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.191
-      },
-      "route-02": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.181
-      },
-      "route-03": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 0.8403030283801005,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.203
+        "seconds": 0.406
+      },
+      "route-02": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.393
+      },
+      "route-03": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.393
       },
       "route-04": {
         "cjk": false,
@@ -842,39 +312,39 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.196
+        "seconds": 0.401
       },
       "route-05": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.186
-      },
-      "route-06": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 0.8403030283801005,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.193
+        "seconds": 0.401
       },
-      "route-07": {
+      "route-06": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.209
+        "seconds": 0.393
       },
-      "route-08": {
+      "route-07": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 0.8403030283801005,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.187
+        "seconds": 0.398
+      },
+      "route-08": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.401
       },
       "route-09": {
         "cjk": false,
@@ -882,15 +352,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.18
+        "seconds": 0.397
       },
       "route-10": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.8821211986607034,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.223
+        "seconds": 0.431
       },
       "route-11": {
         "cjk": false,
@@ -898,7 +368,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.205
+        "seconds": 0.437
       },
       "route-12": {
         "cjk": false,
@@ -906,31 +376,31 @@
         "doc_ndcg": 0.8403030283801005,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.2
+        "seconds": 0.42
       },
       "route-13": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.6387878864795979,
+        "doc_ndcg": 0.762346330035624,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.162
+        "seconds": 0.403
       },
       "route-14": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.171
-      },
-      "route-15": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.206
+        "seconds": 0.414
+      },
+      "route-15": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 0,
+        "ndcg": null,
+        "seconds": 0.398
       },
       "route-16": {
         "cjk": false,
@@ -938,7 +408,7 @@
         "doc_ndcg": 0.7224242270408039,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.185
+        "seconds": 0.392
       },
       "route-17": {
         "cjk": false,
@@ -946,7 +416,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.183
+        "seconds": 0.393
       },
       "route-18": {
         "cjk": false,
@@ -954,7 +424,7 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.208
+        "seconds": 0.407
       },
       "route-19": {
         "cjk": false,
@@ -962,79 +432,79 @@
         "doc_ndcg": 0.8403030283801005,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.171
+        "seconds": 0.403
       },
       "route-20": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.6584645692843067,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.233
+        "seconds": 0.415
       },
       "route-21": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.6363230818084125,
-        "dochit3": 0,
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.215
+        "seconds": 0.411
       },
       "trap-01": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.173
+        "seconds": 0.444
       },
       "trap-02": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
+        "doc_ndcg": 0.43067655807339306,
+        "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.275
+        "seconds": 0.461
       },
       "trap-03": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 1.0,
-        "seconds": 0.193
+        "ndcg": 0.0,
+        "seconds": 0.425
       },
       "trap-04": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 0.5,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3562071871080222,
-        "seconds": 0.23
+        "ndcg": 1.0,
+        "seconds": 0.423
       },
       "trap-05": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 0.6309297535714575,
-        "dochit3": 1,
+        "doc_ndcg": 0.3333333333333333,
+        "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.172
+        "seconds": 0.422
       },
       "trap-06": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 0.0,
+        "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.167
+        "seconds": 0.442
       },
       "trap-07": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.0,
-        "seconds": 0.212
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.412
       },
       "trap-08": {
         "cjk": false,
@@ -1042,7 +512,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.385
+        "seconds": 0.404
       },
       "trap-09": {
         "cjk": false,
@@ -1050,15 +520,545 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.207
+        "seconds": 0.401
       },
       "trap-10": {
         "cjk": false,
         "class": "trap",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.412
+      }
+    },
+    "keyword": {
+      "concept-01": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.75
+      },
+      "concept-02": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.3562071871080222,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.727
+      },
+      "concept-03": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.31546487678572877,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.771
+      },
+      "concept-04": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.759
+      },
+      "concept-05": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.716
+      },
+      "concept-06": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.774
+      },
+      "concept-07": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.321
+      },
+      "concept-08": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.31546487678572877,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.759
+      },
+      "concept-09": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.745
+      },
+      "concept-10": {
+        "cjk": false,
+        "class": "concept",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.765
+      },
+      "needle-01": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.39
+      },
+      "needle-02": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.325
+      },
+      "needle-03": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.339
+      },
+      "needle-04": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.6309297535714575,
+        "seconds": 0.746
+      },
+      "needle-05": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.339
+      },
+      "needle-06": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.323
+      },
+      "needle-07": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.322
+      },
+      "needle-08": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.43067655807339306,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.746
+      },
+      "needle-09": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.327
+      },
+      "needle-10": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.336
+      },
+      "needle-11": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.352
+      },
+      "needle-12": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.335
+      },
+      "needle-13": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.326
+      },
+      "needle-14": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.327
+      },
+      "needle-15": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.707
+      },
+      "needle-16": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.5,
+        "seconds": 0.323
+      },
+      "needle-17": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.323
+      },
+      "needle-18": {
+        "cjk": false,
+        "class": "needle",
         "doc_ndcg": 0.3333333333333333,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.229
+        "seconds": 0.711
+      },
+      "needle-19": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.324
+      },
+      "needle-20": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.334
+      },
+      "needle-21": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.38685280723454163,
+        "seconds": 0.338
+      },
+      "needle-22": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.338
+      },
+      "needle-23": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.43067655807339306,
+        "seconds": 0.341
+      },
+      "needle-24": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.738
+      },
+      "needle-25": {
+        "cjk": false,
+        "class": "needle",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.32
+      },
+      "route-01": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.322
+      },
+      "route-02": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.322
+      },
+      "route-03": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.322
+      },
+      "route-04": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.324
+      },
+      "route-05": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.335
+      },
+      "route-06": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.322
+      },
+      "route-07": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.326
+      },
+      "route-08": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.322
+      },
+      "route-09": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.321
+      },
+      "route-10": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.344
+      },
+      "route-11": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.344
+      },
+      "route-12": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.32
+      },
+      "route-13": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.6387878864795979,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.318
+      },
+      "route-14": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.325
+      },
+      "route-15": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.333
+      },
+      "route-16": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.7224242270408039,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.33
+      },
+      "route-17": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.337
+      },
+      "route-18": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8821211986607034,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.337
+      },
+      "route-19": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.331
+      },
+      "route-20": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.6584645692843067,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.346
+      },
+      "route-21": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.6584645692843067,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.344
+      },
+      "trap-01": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.336
+      },
+      "trap-02": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.379
+      },
+      "trap-03": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 1.0,
+        "seconds": 0.329
+      },
+      "trap-04": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.5,
+        "dochit3": 1,
+        "ndcg": 0.3562071871080222,
+        "seconds": 0.353
+      },
+      "trap-05": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.325
+      },
+      "trap-06": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.32
+      },
+      "trap-07": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.331
+      },
+      "trap-08": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.0,
+        "dochit3": 0,
+        "ndcg": 0.0,
+        "seconds": 0.723
+      },
+      "trap-09": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.334
+      },
+      "trap-10": {
+        "cjk": false,
+        "class": "trap",
+        "doc_ndcg": 0.6309297535714575,
+        "dochit3": 1,
+        "ndcg": 0.0,
+        "seconds": 0.35
       }
     },
     "semantic": {
@@ -1068,7 +1068,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.136
+        "seconds": 0.144
       },
       "concept-02": {
         "cjk": false,
@@ -1076,15 +1076,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.148
+        "seconds": 0.136
       },
       "concept-03": {
         "cjk": false,
         "class": "concept",
-        "doc_ndcg": 0.3562071871080222,
+        "doc_ndcg": 0.43067655807339306,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.197
+        "seconds": 0.164
       },
       "concept-04": {
         "cjk": false,
@@ -1092,7 +1092,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.147
+        "seconds": 0.15
       },
       "concept-05": {
         "cjk": false,
@@ -1100,7 +1100,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.109
+        "seconds": 0.138
       },
       "concept-06": {
         "cjk": false,
@@ -1108,7 +1108,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.159
+        "seconds": 0.169
       },
       "concept-07": {
         "cjk": false,
@@ -1116,7 +1116,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.155
+        "seconds": 0.132
       },
       "concept-08": {
         "cjk": false,
@@ -1124,7 +1124,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.173
+        "seconds": 0.184
       },
       "concept-09": {
         "cjk": false,
@@ -1132,7 +1132,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.128
+        "seconds": 0.145
       },
       "concept-10": {
         "cjk": false,
@@ -1140,7 +1140,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.167
+        "seconds": 0.175
       },
       "needle-01": {
         "cjk": false,
@@ -1148,7 +1148,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.38685280723454163,
-        "seconds": 0.109
+        "seconds": 0.154
       },
       "needle-02": {
         "cjk": false,
@@ -1156,15 +1156,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.109
+        "seconds": 0.127
       },
       "needle-03": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.6309297535714575,
-        "seconds": 0.089
+        "ndcg": 1.0,
+        "seconds": 0.138
       },
       "needle-04": {
         "cjk": false,
@@ -1172,7 +1172,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 1.0,
-        "seconds": 0.108
+        "seconds": 0.129
       },
       "needle-05": {
         "cjk": false,
@@ -1180,7 +1180,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.129
+        "seconds": 0.137
       },
       "needle-06": {
         "cjk": false,
@@ -1188,7 +1188,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.114
+        "seconds": 0.13
       },
       "needle-07": {
         "cjk": false,
@@ -1196,7 +1196,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.104
+        "seconds": 0.126
       },
       "needle-08": {
         "cjk": false,
@@ -1204,7 +1204,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.109
+        "seconds": 0.131
       },
       "needle-09": {
         "cjk": false,
@@ -1212,7 +1212,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.114
+        "seconds": 0.123
       },
       "needle-10": {
         "cjk": false,
@@ -1220,23 +1220,23 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3010299956639812,
-        "seconds": 0.145
+        "seconds": 0.158
       },
       "needle-11": {
         "cjk": false,
         "class": "needle",
-        "doc_ndcg": 0.6309297535714575,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.3562071871080222,
-        "seconds": 0.135
+        "seconds": 0.151
       },
       "needle-12": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 0.6309297535714575,
-        "dochit3": 0,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.133
+        "seconds": 0.149
       },
       "needle-13": {
         "cjk": false,
@@ -1244,7 +1244,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.095
+        "seconds": 0.124
       },
       "needle-14": {
         "cjk": false,
@@ -1252,7 +1252,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.104
+        "seconds": 0.125
       },
       "needle-15": {
         "cjk": false,
@@ -1260,7 +1260,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.093
+        "seconds": 0.132
       },
       "needle-16": {
         "cjk": false,
@@ -1268,7 +1268,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.12
+        "seconds": 0.132
       },
       "needle-17": {
         "cjk": false,
@@ -1276,7 +1276,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.174
+        "seconds": 0.152
       },
       "needle-18": {
         "cjk": false,
@@ -1284,7 +1284,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.145
+        "seconds": 0.131
       },
       "needle-19": {
         "cjk": false,
@@ -1292,7 +1292,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.107
+        "seconds": 0.13
       },
       "needle-20": {
         "cjk": false,
@@ -1300,15 +1300,15 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.6309297535714575,
-        "seconds": 0.085
+        "seconds": 0.13
       },
       "needle-21": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.2890648263178879,
-        "seconds": 0.142
+        "ndcg": 0.0,
+        "seconds": 0.143
       },
       "needle-22": {
         "cjk": false,
@@ -1316,15 +1316,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.112
+        "seconds": 0.142
       },
       "needle-23": {
         "cjk": false,
         "class": "needle",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.3333333333333333,
-        "seconds": 0.117
+        "ndcg": 0.0,
+        "seconds": 0.139
       },
       "needle-24": {
         "cjk": false,
@@ -1332,7 +1332,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.11
+        "seconds": 0.128
       },
       "needle-25": {
         "cjk": false,
@@ -1340,7 +1340,7 @@
         "doc_ndcg": 0.5,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.09
+        "seconds": 0.13
       },
       "route-01": {
         "cjk": false,
@@ -1348,7 +1348,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.09
+        "seconds": 0.136
       },
       "route-02": {
         "cjk": false,
@@ -1356,7 +1356,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.099
+        "seconds": 0.132
       },
       "route-03": {
         "cjk": false,
@@ -1364,7 +1364,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.089
+        "seconds": 0.134
       },
       "route-04": {
         "cjk": false,
@@ -1372,15 +1372,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.104
+        "seconds": 0.193
       },
       "route-05": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.8821211986607034,
+        "doc_ndcg": 0.8599797111848092,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.116
+        "seconds": 0.181
       },
       "route-06": {
         "cjk": false,
@@ -1388,7 +1388,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.086
+        "seconds": 0.13
       },
       "route-07": {
         "cjk": false,
@@ -1396,7 +1396,7 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.115
+        "seconds": 0.137
       },
       "route-08": {
         "cjk": false,
@@ -1404,7 +1404,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.084
+        "seconds": 0.13
       },
       "route-09": {
         "cjk": false,
@@ -1412,7 +1412,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.084
+        "seconds": 0.131
       },
       "route-10": {
         "cjk": false,
@@ -1420,7 +1420,7 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.122
+        "seconds": 0.159
       },
       "route-11": {
         "cjk": false,
@@ -1428,15 +1428,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.132
+        "seconds": 0.157
       },
       "route-12": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.7002827395649097,
+        "doc_ndcg": 0.6862856989769305,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.119
+        "seconds": 0.14
       },
       "route-13": {
         "cjk": false,
@@ -1444,7 +1444,7 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.13
+        "seconds": 0.134
       },
       "route-14": {
         "cjk": false,
@@ -1452,7 +1452,7 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.086
+        "seconds": 0.134
       },
       "route-15": {
         "cjk": false,
@@ -1460,23 +1460,23 @@
         "doc_ndcg": 0.8821211986607034,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.118
+        "seconds": 0.129
       },
       "route-16": {
-        "cjk": false,
-        "class": "route",
-        "doc_ndcg": 0.8403030283801005,
-        "dochit3": 1,
-        "ndcg": null,
-        "seconds": 0.095
-      },
-      "route-17": {
         "cjk": false,
         "class": "route",
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.084
+        "seconds": 0.13
+      },
+      "route-17": {
+        "cjk": false,
+        "class": "route",
+        "doc_ndcg": 0.8403030283801005,
+        "dochit3": 1,
+        "ndcg": null,
+        "seconds": 0.129
       },
       "route-18": {
         "cjk": false,
@@ -1484,15 +1484,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.116
+        "seconds": 0.136
       },
       "route-19": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.8403030283801005,
+        "doc_ndcg": 0.6584645692843067,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.116
+        "seconds": 0.143
       },
       "route-20": {
         "cjk": false,
@@ -1500,15 +1500,15 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.121
+        "seconds": 0.149
       },
       "route-21": {
         "cjk": false,
         "class": "route",
-        "doc_ndcg": 0.8821211986607034,
+        "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": null,
-        "seconds": 0.114
+        "seconds": 0.145
       },
       "trap-01": {
         "cjk": false,
@@ -1516,7 +1516,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.123
+        "seconds": 0.154
       },
       "trap-02": {
         "cjk": false,
@@ -1524,23 +1524,23 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.136
+        "seconds": 0.165
       },
       "trap-03": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 0.5,
-        "dochit3": 0,
+        "doc_ndcg": 1.0,
+        "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.129
+        "seconds": 0.135
       },
       "trap-04": {
         "cjk": false,
         "class": "trap",
         "doc_ndcg": 1.0,
         "dochit3": 1,
-        "ndcg": 0.43067655807339306,
-        "seconds": 0.225
+        "ndcg": 0.5,
+        "seconds": 0.152
       },
       "trap-05": {
         "cjk": false,
@@ -1548,15 +1548,15 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.132
+        "seconds": 0.142
       },
       "trap-06": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 1.0,
-        "dochit3": 1,
+        "doc_ndcg": 0.5,
+        "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.177
+        "seconds": 0.162
       },
       "trap-07": {
         "cjk": false,
@@ -1564,7 +1564,7 @@
         "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.5,
-        "seconds": 0.13
+        "seconds": 0.148
       },
       "trap-08": {
         "cjk": false,
@@ -1572,7 +1572,7 @@
         "doc_ndcg": 0.0,
         "dochit3": 0,
         "ndcg": 0.0,
-        "seconds": 0.116
+        "seconds": 0.132
       },
       "trap-09": {
         "cjk": false,
@@ -1580,107 +1580,44 @@
         "doc_ndcg": 1.0,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.124
+        "seconds": 0.137
       },
       "trap-10": {
         "cjk": false,
         "class": "trap",
-        "doc_ndcg": 1.0,
+        "doc_ndcg": 0.6309297535714575,
         "dochit3": 1,
         "ndcg": 0.0,
-        "seconds": 0.102
+        "seconds": 0.134
       }
     }
   },
   "queries": 66,
-  "single_doc": {
-    "auto": {
-      "n": 45,
-      "ndcg": 0.4883
-    },
-    "keyword": {
-      "n": 45,
-      "ndcg": 0.4191
-    },
-    "semantic": {
-      "n": 45,
-      "ndcg": 0.3671
-    }
-  },
+  "single_doc": {},
   "summary": {
     "auto": {
       "by_class": {
         "concept": {
-          "doc_ndcg": 0.468,
-          "dochit3": 0.5,
+          "doc_ndcg": 0.5139,
+          "dochit3": 0.6,
           "n": 10,
           "ndcg": 0.1631
         },
         "needle": {
-          "doc_ndcg": 0.8071,
-          "dochit3": 0.88,
+          "doc_ndcg": 0.8112,
+          "dochit3": 0.92,
           "n": 25,
-          "ndcg": 0.398
+          "ndcg": 0.3098
         },
         "route": {
-          "doc_ndcg": 0.9271,
-          "dochit3": 0.9048,
-          "n": 21,
-          "ndcg": null
-        },
-        "trap": {
-          "doc_ndcg": 0.6893,
-          "dochit3": 0.8,
-          "n": 10,
-          "ndcg": 0.1815
-        }
-      },
-      "cjk_subset": {
-        "doc_ndcg": 0.0,
-        "dochit3": 0.0,
-        "n": 0,
-        "ndcg": 0.0
-      },
-      "mean_query_seconds": 0.223,
-      "non_cjk": {
-        "doc_ndcg": 0.7761,
-        "dochit3": 0.8182,
-        "n": 66,
-        "ndcg": 0.2977
-      },
-      "overall": {
-        "doc_ndcg": 0.7761,
-        "dochit3": 0.8182,
-        "n": 66,
-        "ndcg": 0.2977
-      },
-      "search_mode_reported": [
-        "hybrid"
-      ]
-    },
-    "keyword": {
-      "by_class": {
-        "concept": {
-          "doc_ndcg": 0.1863,
-          "dochit3": 0.2,
-          "n": 10,
-          "ndcg": 0.0
-        },
-        "needle": {
-          "doc_ndcg": 0.6271,
-          "dochit3": 0.84,
-          "n": 25,
-          "ndcg": 0.3218
-        },
-        "route": {
-          "doc_ndcg": 0.8643,
+          "doc_ndcg": 0.9018,
           "dochit3": 0.9524,
           "n": 21,
           "ndcg": null
         },
         "trap": {
-          "doc_ndcg": 0.6095,
-          "dochit3": 0.7,
+          "doc_ndcg": 0.6087,
+          "dochit3": 0.6,
           "n": 10,
           "ndcg": 0.1356
         }
@@ -1691,16 +1628,66 @@
         "n": 0,
         "ndcg": 0.0
       },
-      "mean_query_seconds": 0.249,
+      "mean_query_seconds": 0.414,
       "non_cjk": {
-        "doc_ndcg": 0.6331,
-        "dochit3": 0.7576,
+        "doc_ndcg": 0.7643,
+        "dochit3": 0.8333,
+        "n": 66,
+        "ndcg": 0.2385
+      },
+      "overall": {
+        "doc_ndcg": 0.7643,
+        "dochit3": 0.8333,
+        "n": 66,
+        "ndcg": 0.2385
+      },
+      "search_mode_reported": [
+        "hybrid"
+      ]
+    },
+    "keyword": {
+      "by_class": {
+        "concept": {
+          "doc_ndcg": 0.2618,
+          "dochit3": 0.3,
+          "n": 10,
+          "ndcg": 0.0
+        },
+        "needle": {
+          "doc_ndcg": 0.7525,
+          "dochit3": 0.92,
+          "n": 25,
+          "ndcg": 0.3218
+        },
+        "route": {
+          "doc_ndcg": 0.8673,
+          "dochit3": 1.0,
+          "n": 21,
+          "ndcg": null
+        },
+        "trap": {
+          "doc_ndcg": 0.6024,
+          "dochit3": 0.8,
+          "n": 10,
+          "ndcg": 0.1356
+        }
+      },
+      "cjk_subset": {
+        "doc_ndcg": 0.0,
+        "dochit3": 0.0,
+        "n": 0,
+        "ndcg": 0.0
+      },
+      "mean_query_seconds": 0.426,
+      "non_cjk": {
+        "doc_ndcg": 0.6919,
+        "dochit3": 0.8333,
         "n": 66,
         "ndcg": 0.2089
       },
       "overall": {
-        "doc_ndcg": 0.6331,
-        "dochit3": 0.7576,
+        "doc_ndcg": 0.6919,
+        "dochit3": 0.8333,
         "n": 66,
         "ndcg": 0.2089
       },
@@ -1711,28 +1698,28 @@
     "semantic": {
       "by_class": {
         "concept": {
-          "doc_ndcg": 0.488,
+          "doc_ndcg": 0.4954,
           "dochit3": 0.6,
           "n": 10,
           "ndcg": 0.1631
         },
         "needle": {
-          "doc_ndcg": 0.7671,
-          "dochit3": 0.8,
+          "doc_ndcg": 0.7967,
+          "dochit3": 0.84,
           "n": 25,
-          "ndcg": 0.2076
+          "ndcg": 0.1975
         },
         "route": {
-          "doc_ndcg": 0.9368,
+          "doc_ndcg": 0.9321,
           "dochit3": 1.0,
           "n": 21,
           "ndcg": null
         },
         "trap": {
-          "doc_ndcg": 0.6393,
+          "doc_ndcg": 0.6024,
           "dochit3": 0.7,
           "n": 10,
-          "ndcg": 0.0931
+          "ndcg": 0.1
         }
       },
       "cjk_subset": {
@@ -1741,18 +1728,18 @@
         "n": 0,
         "ndcg": 0.0
       },
-      "mean_query_seconds": 0.122,
+      "mean_query_seconds": 0.142,
       "non_cjk": {
-        "doc_ndcg": 0.7595,
-        "dochit3": 0.8182,
+        "doc_ndcg": 0.7647,
+        "dochit3": 0.8333,
         "n": 66,
-        "ndcg": 0.1723
+        "ndcg": 0.1682
       },
       "overall": {
-        "doc_ndcg": 0.7595,
-        "dochit3": 0.8182,
+        "doc_ndcg": 0.7647,
+        "dochit3": 0.8333,
         "n": 66,
-        "ndcg": 0.1723
+        "ndcg": 0.1682
       },
       "search_mode_reported": [
         "semantic"

--- a/benchmark_data/financial_reports/modes_results.md
+++ b/benchmark_data/financial_reports/modes_results.md
@@ -75,3 +75,11 @@ optional per-document diversity cap for `pdf_corpus_search`.
 **Route rows show `n/a` for page-level NDCG,** not 0.000: those labels
 carry no page, so a page-level score does not exist for them. They are
 excluded from the page-level means rather than counted as zeros.
+
+**Single-doc arm not re-run for the document-arm pass.** The document-arm
+work (`feat/doc-profile-routing`) re-ran this corpus's corpus-wide
+figures pre-arm vs. post-arm (see `benchmark_data/corpus_search/modes_results_500.md`,
+"Held-out 10-K corpus"), but did not pass `--single-doc-arm` here, so the
+single-doc `pdf_search` figures above were not regenerated in that pass.
+They stand unchanged: `pdf_search` is untouched by the document-arm work
+on this branch.

--- a/benchmark_data/financial_reports/modes_results.md
+++ b/benchmark_data/financial_reports/modes_results.md
@@ -4,9 +4,9 @@ Corpus: 24 docs. Queries: 66 (graded ground truth over 8 filers x 3 fiscal years
 
 | mode | overall NDCG@10 | concept | needle | route | trap | doc-hit@3 | s/query |
 |---|---|---|---|---|---|---|---|
-| keyword (keyword) | 0.209 | 0.000 | 0.322 | n/a | 0.136 | 0.758 | 0.25 |
-| semantic (semantic) | 0.172 | 0.163 | 0.208 | n/a | 0.093 | 0.818 | 0.12 |
-| auto (hybrid) | 0.298 | 0.163 | 0.398 | n/a | 0.181 | 0.818 | 0.22 |
+| keyword (keyword) | 0.209 | 0.000 | 0.322 | n/a | 0.136 | 0.833 | 0.43 |
+| semantic (semantic) | 0.168 | 0.163 | 0.198 | n/a | 0.100 | 0.833 | 0.14 |
+| auto (hybrid) | 0.238 | 0.163 | 0.310 | n/a | 0.136 | 0.833 | 0.41 |
 
 ## Doc-level NDCG@10 (ranked docs deduped, gain = doc's best label)
 
@@ -14,19 +14,9 @@ Separates "wrong doc" from "right doc, unlabeled page": sparse page labels grade
 
 | mode | overall | concept | needle | route | trap |
 |---|---|---|---|---|---|
-| keyword | 0.633 | 0.186 | 0.627 | 0.864 | 0.610 |
-| semantic | 0.759 | 0.488 | 0.767 | 0.937 | 0.639 |
-| auto | 0.776 | 0.468 | 0.807 | 0.927 | 0.689 |
-
-## Single-doc arm (pdf_search against the one gold document)
-
-The common agent flow: a question asked of a single known document, not the whole corpus. Same page labels, restricted to queries whose gold pages sit in exactly one document.
-
-| mode | NDCG@10 | n |
-|---|---|---|
-| keyword | 0.419 | 45 |
-| semantic | 0.367 | 45 |
-| auto | 0.488 | 45 |
+| keyword | 0.692 | 0.262 | 0.752 | 0.867 | 0.602 |
+| semantic | 0.765 | 0.495 | 0.797 | 0.932 | 0.602 |
+| auto | 0.764 | 0.514 | 0.811 | 0.902 | 0.609 |
 
 Page-level NDCG is floored by label sparsity on this corpus: one labeled page per needle against 3,545 pages in which the same phrasing recurs across fiscal years and across MD&A, the notes and the segment sections. Cite the doc-level table. Interpretation is appended by hand after the run.
 ## Interpretation

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ detail lives in [`CHANGELOG.md`](../CHANGELOG.md).
 - **MCP Registry:** published (v3.0.0)
 - **Tools:** 13 released (`pdf_info`, `pdf_read_pages`, `pdf_read_all`, `pdf_search`, `pdf_get_toc`, `pdf_render_pages`, `pdf_extract_chart`, `pdf_corpus_warm`, `pdf_corpus_overview`, `pdf_corpus_search`, `pdf_cache_stats`, `pdf_cache_clear`, `server_info`)
 - **Transports:** STDIO (`pdf-mcp`) and single-tenant HTTP (`pdf-mcp-http`); multi-arch Docker images at `ghcr.io/jztan/pdf-mcp`, tagged per release
-- **Tests:** 1687, on Linux (Python 3.10 to 3.14) and Windows (3.10, 3.13). The release gate runs `pytest -m "not slow"`.
+- **Tests:** 1761, on Linux (Python 3.10 to 3.14) and Windows (3.10, 3.13). The release gate runs `pytest -m "not slow"`.
 
 ---
 
@@ -42,6 +42,8 @@ _Nothing queued._
 
 ### P1: high-value, well-scoped
 
+- [ ] **Fix the silent partial warm**: `pdf_corpus_warm` once reported `unprocessed: []` with 21 of 500 documents unwarmed; must be closed before any cap raise
+- [ ] **Raise `CORPUS_MAX_FILES` to 500**, measured with the document arm (500 docs: described doc-hit@3 0.68, needle 1.000, trap 0.985, 3 s/query); 1,000 waits on the 900-distractor rung
 - [ ] **`pdf_corpus_warm`: commit embeddings in page batches**, so a giant document can finish inside a client timeout
 - [ ] **Teach keyword-mode query shape in the tool descriptions**, since AND-joined terms silently return nothing
 - [ ] **Calibrate the semantic confidence threshold**; 0.5 is a guess and gibberish scores 0.54

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -885,6 +885,7 @@ Searches a folder or explicit list of local PDFs and returns one relevance-ranke
 - Semantic and hybrid modes require fastembed (included in the default install) and, for hybrid to actually fuse (rather than degrade to keyword), warmed embeddings; call `pdf_corpus_warm(paths, embeddings=True)` first to warm a corpus outside this call's budget.
 - The document arm reads page 1 only; a document whose first page is a blank cover or an image gets no profile and is ranked by the page arms alone.
 - `about` terms and the document arm's term lists tokenise Latin words only; CJK documents get an empty `about`.
+- The document arm judges a document by its first page, so a paper whose abstract is about one thing but which *uses* the queried method deep inside can lose its top-3 slot to a paper whose abstract mentions the method. Measured cost across corpus sizes 50 to 500: one spread query at 100 documents or fewer, none above; described queries improve at every size (`benchmark_data/corpus_search/doc_arm_size_sweep.md`).
 
 **Example:**
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -765,6 +765,7 @@ Warms a folder or explicit list of local PDFs into the cache: text extraction, a
 **Returns:**
 - `docs` (array, sorted by path): `[{path, status: "warmed" | "cached", pages, embeddings_cached}, ...]`. `embeddings_cached` reports actual per-doc cache state for the configured embedding model (not an echo of the `embeddings` request flag), so a cheap text-only call answers "do I need an embeddings pass before semantic search?".
 - Shared envelope fields above (`unprocessed`, `skipped`, `corpus_size`, `warmed_this_call`, `budget_exhausted`).
+- With `embeddings=True`, already-cached documents also get their document profile (used by `pdf_corpus_search` hybrid mode and `pdf_corpus_overview.about`) backfilled at no budget cost.
 
 **Limitations:**
 - The 100-file cap, budget clamp, and URL rejection described above apply.
@@ -807,6 +808,7 @@ Returns a per-document triage card for every PDF in a folder or list: title, pag
   - `title`: PDF metadata title, falling back to the filename stem when absent or a known placeholder — never `null` (same contract as `pdf_corpus_search`'s `doc_title`). **Untrusted content from the PDF** when it comes from metadata.
   - `toc_top`: depth-1 TOC entry titles, capped at 8.
   - `text_coverage`: `"full"`, `"partial"`, or `"none"`, derived from per-page text character counts.
+  - `about` (array): up to 8 of the document's most distinctive terms relative to the corpus, by tf-idf over cached term lists; `[]` until the document has a profile.
 - Shared envelope fields above (`unprocessed`, `skipped`, `corpus_size`, `warmed_this_call`, `budget_exhausted`).
 
 **Limitations:**
@@ -858,7 +860,7 @@ Searches a folder or explicit list of local PDFs and returns one relevance-ranke
   - `doc_title`: the PDF's metadata title (placeholder titles like "Untitled..." and scanner artifacts carrying a `___` marker filtered out), falling back to the filename stem when no usable title exists — never `null`. Metadata titles are **untrusted content from the PDF.**
   - Keyword-mode hits also carry `score` (per-doc BM25; comparable only within that hit's own document, since RRF governs cross-document order, not the raw score).
   - Semantic-mode hits carry `score` (cosine, rounded to 4dp) and `low_confidence` (cosine below `confidence_threshold`), matching single-doc `pdf_search(mode="semantic")`.
-  - Hybrid (`auto` with embeddings available) hits carry `score` (fused RRF score, rounded to 4dp), `semantic_score` (cosine, rounded to 4dp; `0.0` when the page had no cached embedding), and `low_confidence` (page absent from the keyword arm's hits AND `semantic_score` below `confidence_threshold`), matching single-doc `pdf_search(mode="auto")`'s hybrid hits.
+  - Hybrid (`auto` with embeddings available) hits carry `score` (fused RRF score, rounded to 4dp), `semantic_score` (cosine, rounded to 4dp; `0.0` when the page had no cached embedding), and `low_confidence` (page absent from the keyword arm's hits AND `semantic_score` below `confidence_threshold`), matching single-doc `pdf_search(mode="auto")`'s hybrid hits, and `doc_score` (head-vector cosine of the match's document, 4 dp; `null` when the document has no profile).
 - `total_matches` (int): `len(matches)`.
 - `doc_match_counts` (object): per-doc hit count keyed by path — **which documents hold content for this query, including documents whose pages did not win a slot in `matches`**. For a question spanning several documents ("compare A with B", "the trend across three years"), re-ask every document listed here with `pdf_search`, not just the top matches: measured on both benchmark corpora, stopping after the top few documents recovers only about half of a multi-document answer (~65% at 5 documents vs ~87% checking everything named, each extra search ~0.5s on a warmed corpus). In keyword mode it is the keyword arm's per-doc FTS hit count, capped at `top_k` per document; in hybrid mode it merges both arms (max per document, since the arms are two views of the same pages), so a question-shaped query the keyword arm cannot match still reports the documents the semantic arm found; in pure semantic mode it's how many of that doc's pages landed in the global `top_k`. Counts are independent of which pages the fused ranking selects.
 - `search_mode` (string): `"keyword"`, `"semantic"`, or `"hybrid"`, the mode actually run (`"auto"` resolves to `"hybrid"` when embeddings are available, else `"keyword"`).
@@ -867,6 +869,7 @@ Searches a folder or explicit list of local PDFs and returns one relevance-ranke
 - `hidden_text_detected` (bool): `true` if any returned hit's page carries text invisible to a human reader.
 - `unprocessed`, `skipped`, `corpus_size`, `warmed_this_call`, `budget_exhausted`: same shared envelope as `pdf_corpus_warm`/`pdf_corpus_overview`.
 - `semantic_unprocessed` (array, semantic/hybrid only): paths that were warmed/cached but had no cached embeddings (e.g. warming raced the embeddings budget); additive to `unprocessed`.
+- `doc_profile_coverage` (object, hybrid only): `{"profiled": n, "searched": m}`. Hybrid mode fuses a third, document-level arm: each document's cached head vector (page 1, first 1,500 characters, same embedding model as pages) ranks documents by cosine at a fixed weight of 0.25 against the two page arms, so a document the page arms never surfaced can still reach `matches` and `doc_match_counts`. Profiles are written at warm and backfilled from cached text on first search; `profiled < searched` means the arm ran over a subset (backfill pending, or page 1 has no text). `pdf_corpus_warm(paths, embeddings=True)` closes the gap.
 - `all_results_low_confidence`, `confidence_threshold` (semantic and hybrid modes only).
 - `model_name` (semantic mode only): the embedding model used.
 - `semantic_unavailable`, `semantic_unavailable_reason` (auto mode only): present when embeddings are unavailable and the search degraded to keyword.
@@ -880,6 +883,8 @@ Searches a folder or explicit list of local PDFs and returns one relevance-ranke
 - The 100-file cap, budget clamp, and URL rejection shared with `pdf_corpus_warm`/`pdf_corpus_overview` apply.
 - Keyword terms are AND-matched independently per document (FTS5); use short, specific terms and drop rare extra words, since a full question or one uncommon word can return nothing even when a document is otherwise relevant.
 - Semantic and hybrid modes require fastembed (included in the default install) and, for hybrid to actually fuse (rather than degrade to keyword), warmed embeddings; call `pdf_corpus_warm(paths, embeddings=True)` first to warm a corpus outside this call's budget.
+- The document arm reads page 1 only; a document whose first page is a blank cover or an image gets no profile and is ranked by the page arms alone.
+- `about` terms and the document arm's term lists tokenise Latin words only; CJK documents get an empty `about`.
 
 **Example:**
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -808,7 +808,7 @@ Returns a per-document triage card for every PDF in a folder or list: title, pag
   - `title`: PDF metadata title, falling back to the filename stem when absent or a known placeholder — never `null` (same contract as `pdf_corpus_search`'s `doc_title`). **Untrusted content from the PDF** when it comes from metadata.
   - `toc_top`: depth-1 TOC entry titles, capped at 8.
   - `text_coverage`: `"full"`, `"partial"`, or `"none"`, derived from per-page text character counts.
-  - `about` (array): up to 8 of the document's most distinctive terms relative to the corpus, by tf-idf over cached term lists; `[]` until the document has a profile.
+  - `about` (array): up to 8 of the document's most distinctive terms relative to the corpus, by tf-idf over cached term lists; `[]` until the document has a profile. A profile is written by `pdf_corpus_warm(paths, embeddings=True)` or by a hybrid `pdf_corpus_search`; a text-only warm, including the one this tool runs by default, leaves it `[]`.
 - Shared envelope fields above (`unprocessed`, `skipped`, `corpus_size`, `warmed_this_call`, `budget_exhausted`).
 
 **Limitations:**
@@ -869,7 +869,7 @@ Searches a folder or explicit list of local PDFs and returns one relevance-ranke
 - `hidden_text_detected` (bool): `true` if any returned hit's page carries text invisible to a human reader.
 - `unprocessed`, `skipped`, `corpus_size`, `warmed_this_call`, `budget_exhausted`: same shared envelope as `pdf_corpus_warm`/`pdf_corpus_overview`.
 - `semantic_unprocessed` (array, semantic/hybrid only): paths that were warmed/cached but had no cached embeddings (e.g. warming raced the embeddings budget); additive to `unprocessed`.
-- `doc_profile_coverage` (object, hybrid only): `{"profiled": n, "searched": m}`. Hybrid mode fuses a third, document-level arm: each document's cached head vector (page 1, first 1,500 characters, same embedding model as pages) ranks documents by cosine at a fixed weight of 0.25 against the two page arms, so a document the page arms never surfaced can still reach `matches` and `doc_match_counts`. Profiles are written at warm and backfilled from cached text on first search; `profiled < searched` means the arm ran over a subset (backfill pending, or page 1 has no text). `pdf_corpus_warm(paths, embeddings=True)` closes the gap.
+- `doc_profile_coverage` (object, hybrid only): `{"profiled": n, "searched": m}`. Hybrid mode fuses a third, document-level arm: each document's cached head vector (page 1, first 1,500 characters, same embedding model as pages) ranks documents by cosine at a fixed weight of 0.25 against the two page arms, so a document the page arms never surfaced can still reach `matches` and `doc_match_counts`. Profiles are written at warm and backfilled from cached text on first search; `profiled < searched` means the arm ran over a subset (backfill pending, or page 1 has no text). `pdf_corpus_warm(paths, embeddings=True)` closes the gap. `profiled` counts documents holding a head vector, which can exceed the documents the arm actually ranked: a document can have a profile but no page embeddings to anchor it to a result page.
 - `all_results_low_confidence`, `confidence_threshold` (semantic and hybrid modes only).
 - `model_name` (semantic mode only): the embedding model used.
 - `semantic_unavailable`, `semantic_unavailable_reason` (auto mode only): present when embeddings are unavailable and the search degraded to keyword.

--- a/pages/index.html
+++ b/pages/index.html
@@ -1318,7 +1318,36 @@ estimated_tokens: 1740</pre>
     return topK !== null ? fused.slice(0, topK) : fused;
   }
 
-  const corpusFusion = { CORPUS_RRF_K, corpusQueryTerms, docCoveredTerms, corpusCoverageScores, rrfFuseDocRankings };
+  const PROFILE_TERM_LIMIT = 200;
+  // Mirrors corpus.profile_terms: 4+ char tokens across all pages, top 200
+  // by count, ties by term. Insertion order of the returned Map is the
+  // ranked order.
+  function profileTerms(pageTexts) {
+    const counts = new Map();
+    for (const text of pageTexts)
+      for (const t of (text.toLowerCase().match(/[a-z0-9]+/g) || []))
+        if (t.length > 3) counts.set(t, (counts.get(t) || 0) + 1);
+    const top = [...counts].sort((a, b) => (b[1] - a[1]) || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    return new Map(top.slice(0, PROFILE_TERM_LIMIT));
+  }
+  // Mirrors corpus.about_terms: tf * log(1 + N / df), top `limit`, ties by term.
+  function aboutTerms(termsByPath, nDocs, limit = 8) {
+    const df = new Map();
+    for (const terms of termsByPath.values())
+      for (const t of terms.keys()) df.set(t, (df.get(t) || 0) + 1);
+    const out = new Map();
+    for (const [path, terms] of termsByPath) {
+      const ranked = [...terms].sort((a, b) => {
+        const sa = a[1] * Math.log(1 + nDocs / df.get(a[0]));
+        const sb = b[1] * Math.log(1 + nDocs / df.get(b[0]));
+        return (sb - sa) || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0);
+      });
+      out.set(path, ranked.slice(0, limit).map(([t]) => t));
+    }
+    return out;
+  }
+
+  const corpusFusion = { CORPUS_RRF_K, corpusQueryTerms, docCoveredTerms, corpusCoverageScores, rrfFuseDocRankings, profileTerms, aboutTerms };
   /* __PDF_MCP_CORPUS_FUSION_END__ */
 
   // Port of corpus._clean_title: filters generic/empty PDF titles.
@@ -1651,6 +1680,8 @@ estimated_tokens: 1740</pre>
   }
 
   function buildCorpusOverviewJson() {
+    const termsByPath = new Map(corpusState.docs.map((d) => [d.path, corpusFusion.profileTerms(d.pageTexts)]));
+    const about = corpusFusion.aboutTerms(termsByPath, corpusState.docs.length);
     return {
       docs: corpusState.docs.map((d) => ({
         path: d.path,
@@ -1659,6 +1690,7 @@ estimated_tokens: 1740</pre>
         toc_top: d.tocTop,
         has_toc: d.hasToc,
         text_coverage: textCoverageLabel(d.pageTexts),
+        about: about.get(d.path) || [],
         size_bytes: d.sizeBytes,
         from_cache: false,
       })),

--- a/pages/index.html
+++ b/pages/index.html
@@ -879,6 +879,7 @@
             <div id="corpusWarmPanel"></div>
             <div class="hidden" id="corpusOverviewTag" style="margin-top:14px"><span class="tool-tag" style="margin-left:0">pdf_corpus_overview · <button class="step-json-toggle" data-target="cjson2">{ JSON }</button></span></div>
             <div id="corpusOverviewPanel" class="hidden"></div>
+            <div class="callout info" id="corpusOverviewCallout" style="display:none"></div>
             <div id="corpusSearchPanel" class="hidden">
               <div class="askbar">
                 <input type="text" id="corpusSearchInput" placeholder="Ask these documents for something…" />
@@ -1512,6 +1513,8 @@ estimated_tokens: 1740</pre>
     $("corpusResults").innerHTML = "";
     $("corpusCallout").style.display = "none";
     $("corpusCallout").innerHTML = "";
+    $("corpusOverviewCallout").style.display = "none";
+    $("corpusOverviewCallout").innerHTML = "";
     $("corpusOverviewTag").classList.add("hidden");
     $("cjson1").classList.remove("open"); $("cjson1-content").innerHTML = "";
     $("cjson2").classList.add("hidden"); $("cjson2").classList.remove("open"); $("cjson2-content").innerHTML = "";
@@ -1733,6 +1736,9 @@ estimated_tokens: 1740</pre>
     document.getElementById("corpusSearchPanel").classList.remove("hidden");
     renderCorpusGrids();
     renderCorpusChips();
+    const ovco = document.getElementById("corpusOverviewCallout");
+    ovco.style.display = "";
+    ovco.innerHTML = "<span>This demo computes <code>about</code> in-browser from the corpus you just gave it. The installed server fills it the same way, but only after an embeddings warm (<code>pdf_corpus_warm(paths, embeddings=True)</code>), so a text-only warm shows an empty list until then.</span>";
   }
 
   const CORPUS_TOP_K = 10;

--- a/scripts/benchmark_corpus_modes.py
+++ b/scripts/benchmark_corpus_modes.py
@@ -406,7 +406,7 @@ def main(argv: list[str] | None = None) -> int:
     queries = json.loads((data / "queries.json").read_text(encoding="utf-8"))
     classes = class_names(queries)
     subset_ids = nonlatin_ids(manifest)
-    id_by_path = {str(REPO / d["path"]): d["id"] for d in manifest["docs"]}
+    id_by_path = {str((REPO / d["path"]).resolve()): d["id"] for d in manifest["docs"]}
 
     if args.validate:
         import pymupdf

--- a/scripts/check_demo_fusion_parity.mjs
+++ b/scripts/check_demo_fusion_parity.mjs
@@ -58,5 +58,19 @@ for (const name of ["rrf_no_scores", "rrf_scores_tiebreak", "rrf_topk"]) {
   }
 }
 
+{
+  const c = fx.about_terms;
+  const termsByPath = new Map();
+  for (const [path, pages] of Object.entries(c.docs)) {
+    const got = F.profileTerms(Object.keys(pages).sort((a, b) => a - b).map((k) => pages[k]));
+    if (!eqJson(Object.fromEntries(got), c.expected_terms[path])) fail(`profileTerms(${path})`, Object.fromEntries(got), c.expected_terms[path]);
+    termsByPath.set(path, got);
+  }
+  const about = F.aboutTerms(termsByPath, Object.keys(c.docs).length);
+  for (const [path, want] of Object.entries(c.expected_about)) {
+    if (!eqJson(about.get(path), want)) fail(`aboutTerms(${path})`, about.get(path), want);
+  }
+}
+
 if (fails) { console.error(`${fails} failure(s)`); process.exit(1); }
 console.log("parity OK");

--- a/scripts/gen_demo_fusion_fixtures.py
+++ b/scripts/gen_demo_fusion_fixtures.py
@@ -24,6 +24,16 @@ from pdf_mcp.server import _corpus_query_terms  # noqa: E402
 TERM_RE = re.compile(r"[a-z0-9]+")
 
 
+class _TermsCache:
+    """Minimal cache stand-in: about_terms only calls get_doc_terms."""
+
+    def __init__(self, terms_by_path):
+        self._t = terms_by_path
+
+    def get_doc_terms(self, paths):
+        return {p: self._t[p] for p in paths if p in self._t}
+
+
 def covered_terms(texts: list[str], terms: set[str]) -> set[str]:
     found: set[str] = set()
     for text in texts:
@@ -129,6 +139,20 @@ def main() -> None:
     fixtures["coverage_scores"] = {
         "covered": {p: sorted(t) for p, t in cov.items()},
         "expected": _corpus_coverage_scores(cov),
+    }
+
+    docs_terms = {
+        "/a.pdf": {0: "the cat budget budget alpha", 1: "Alpha REPORT"},
+        "/b.pdf": {0: "bravo budget report report"},
+        "/c.pdf": {0: "charlie budget"},
+    }
+    fixtures["about_terms"] = {
+        "docs": {p: {str(k): v for k, v in t.items()} for p, t in docs_terms.items()},
+        "expected_terms": {p: corpus.profile_terms(t) for p, t in docs_terms.items()},
+        "expected_about": corpus.about_terms(
+            _TermsCache({p: corpus.profile_terms(t) for p, t in docs_terms.items()}),
+            list(docs_terms),
+        ),
     }
 
     docs = {

--- a/src/pdf_mcp/cache.py
+++ b/src/pdf_mcp/cache.py
@@ -452,6 +452,8 @@ class PDFCache:
                 conn.execute("DROP TABLE IF EXISTS pdf_section_fts_cjk")
                 # Derived from the same extraction pipeline as page_text.
                 conn.execute("DROP TABLE IF EXISTS page_blocks")
+                # Head text and term counts derive from page_text.
+                conn.execute("DROP TABLE IF EXISTS doc_profiles")
             if extraction_version < _EXTRACTION_VERSION:
                 conn.execute(f"PRAGMA user_version = {_EXTRACTION_VERSION}")
 
@@ -609,6 +611,22 @@ class PDFCache:
 
                 CREATE INDEX IF NOT EXISTS idx_page_embeddings_path
                     ON page_embeddings(file_path);
+
+                -- Per-document profile: head vector (page 1, first
+                -- PROFILE_HEAD_CHARS chars) for the corpus search's document
+                -- arm, plus term counts for overview `about`. One row per
+                -- document; mtime + model validated on read like
+                -- page_embeddings. embedding is NULL when page 1 had no text.
+                CREATE TABLE IF NOT EXISTS doc_profiles (
+                    file_path   TEXT    NOT NULL,
+                    file_mtime  REAL    NOT NULL,
+                    model       TEXT    NOT NULL,
+                    head_chars  INTEGER NOT NULL,
+                    embedding   BLOB,
+                    terms       TEXT    NOT NULL,
+                    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (file_path)
+                );
 
                 -- Section embeddings cache (Phase-1 validation shim;
                 -- mirrors page_embeddings, keyed by section_id within a PDF).
@@ -1648,6 +1666,71 @@ class PDFCache:
                 (model_name, path, mtime),
             ).fetchall()
         return all(not (text or "").strip() for (text,) in rows)
+
+    def save_doc_profile(
+        self,
+        path: str,
+        head_chars: int,
+        embedding: "bytes | None",
+        terms: dict[str, int],
+        model_name: str,
+        conn: "sqlite3.Connection | None" = None,
+    ) -> None:
+        """Persist one document's profile (see corpus.build_doc_profile).
+
+        ``embedding`` is None when page 1 carried no text; the row is
+        still written so a backfill does not retry it forever. Keyed on
+        file_path alone: a new model or mtime simply replaces the row.
+        """
+        mtime, _ = self._get_file_info(path)
+        with self._write_conn(conn) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO doc_profiles"
+                " (file_path, file_mtime, model, head_chars, embedding, terms)"
+                " VALUES (?, ?, ?, ?, ?, ?)",
+                (path, mtime, model_name, head_chars, embedding, json.dumps(terms)),
+            )
+
+    def _doc_profile_rows(self, paths: list[str]) -> list[tuple[Any, ...]]:
+        """Raw doc_profiles rows for paths whose stored mtime matches the
+        file's current mtime. Files that no longer exist are skipped."""
+        if not paths:
+            return []
+        current: dict[str, float] = {}
+        for p in paths:
+            try:
+                current[p] = self._get_file_info(p)[0]
+            except OSError:
+                continue
+        if not current:
+            return []
+        out: list[tuple[Any, ...]] = []
+        keys = list(current)
+        with self._connect() as conn:
+            for i in range(0, len(keys), 500):
+                chunk = keys[i : i + 500]
+                placeholders = ",".join("?" * len(chunk))
+                rows = conn.execute(
+                    "SELECT file_path, file_mtime, model, embedding, terms"
+                    f" FROM doc_profiles WHERE file_path IN ({placeholders})",
+                    chunk,
+                ).fetchall()
+                out.extend(r for r in rows if r[1] == current[r[0]])
+        return out
+
+    def get_doc_profiles(
+        self, paths: list[str], model_name: str
+    ) -> "dict[str, bytes | None]":
+        """{path: head-vector blob or None} for valid (mtime, model) rows.
+
+        None means "profiled, but page 1 had no text": the document has no
+        vector and the caller should neither score nor re-encode it.
+        """
+        return {r[0]: r[3] for r in self._doc_profile_rows(paths) if r[2] == model_name}
+
+    def get_doc_terms(self, paths: list[str]) -> dict[str, dict[str, int]]:
+        """{path: {term: count}} for mtime-valid rows, any model."""
+        return {r[0]: json.loads(r[4]) for r in self._doc_profile_rows(paths)}
 
     def get_section_embeddings(
         self, path: str, section_ids: list[int]

--- a/src/pdf_mcp/cache.py
+++ b/src/pdf_mcp/cache.py
@@ -1969,6 +1969,7 @@ class PDFCache:
             conn.execute("DELETE FROM page_images WHERE file_path = ?", (path,))
             conn.execute("DELETE FROM page_tables WHERE file_path = ?", (path,))
             conn.execute("DELETE FROM page_embeddings WHERE file_path = ?", (path,))
+            conn.execute("DELETE FROM doc_profiles WHERE file_path = ?", (path,))
             conn.execute(
                 "DELETE FROM section_embeddings WHERE file_path = ?",
                 (path,),
@@ -2033,6 +2034,10 @@ class PDFCache:
                 conn.execute(
                     f"DELETE FROM page_embeddings"
                     f" WHERE file_path IN ({placeholders})",
+                    expired_paths,
+                )
+                conn.execute(
+                    f"DELETE FROM doc_profiles WHERE file_path IN ({placeholders})",
                     expired_paths,
                 )
                 conn.execute(
@@ -2111,6 +2116,7 @@ class PDFCache:
             conn.execute("DELETE FROM page_images")
             conn.execute("DELETE FROM page_tables")
             conn.execute("DELETE FROM page_embeddings")
+            conn.execute("DELETE FROM doc_profiles")
             conn.execute("DELETE FROM section_embeddings")
             conn.execute("DELETE FROM page_renders")
             conn.execute("DELETE FROM page_charts")

--- a/src/pdf_mcp/corpus.py
+++ b/src/pdf_mcp/corpus.py
@@ -11,6 +11,7 @@ caller; this module owns no storage of its own.
 from __future__ import annotations
 
 import logging
+import math
 import multiprocessing
 import re
 import time
@@ -35,6 +36,7 @@ __all__ = [
     "resolve_corpus",
     "warm_docs",
     "text_coverage_label",
+    "about_terms",
     "build_overview_card",
     "rrf_fuse_doc_rankings",
     "rrf_fuse_rankings_scored",
@@ -702,6 +704,34 @@ def text_coverage_label(coverage: list[dict[str, int]]) -> str:
     return "partial"
 
 
+def about_terms(cache: Any, paths: list[str], limit: int = 8) -> dict[str, list[str]]:
+    """Each document's most distinctive stored terms relative to the corpus.
+
+    tf * log(1 + N / df) over the cached term lists only (no page text
+    read). A readability aid on overview cards, validated by inspection;
+    it makes no retrieval claim. Latin tokens only: CJK documents get an
+    empty list (documented limitation).
+    """
+    terms_by_doc = cache.get_doc_terms(paths)
+    n_docs = len(paths)
+    df: dict[str, int] = {}
+    for terms in terms_by_doc.values():
+        for t in terms:
+            df[t] = df.get(t, 0) + 1
+    out: dict[str, list[str]] = {}
+    for path in paths:
+        terms = terms_by_doc.get(path)
+        if not terms:
+            out[path] = []
+            continue
+        ranked = sorted(
+            terms.items(),
+            key=lambda kv: (-kv[1] * math.log(1.0 + n_docs / df[kv[0]]), kv[0]),
+        )
+        out[path] = [t for t, _c in ranked[:limit]]
+    return out
+
+
 # Exporter boilerplate that reads as "no title" for triage purposes.
 # Matched case-insensitively; "untitled" is a prefix match (iWork
 # exports produce e.g. "Untitled 3.pages").
@@ -729,7 +759,12 @@ def _clean_title(title: Any) -> str | None:
     return stripped
 
 
-def build_overview_card(path: str, cache: Any, from_cache: bool) -> dict[str, Any]:
+def build_overview_card(
+    path: str,
+    cache: Any,
+    from_cache: bool,
+    about: list[str] | None = None,
+) -> dict[str, Any]:
     """Build one triage card from cached data only (doc must be warm).
 
     Junk metadata is filtered rather than passed through: whitespace-only
@@ -754,6 +789,7 @@ def build_overview_card(path: str, cache: Any, from_cache: bool) -> dict[str, An
         # as no TOC. Any level counts, not just the level-1 preview.
         "has_toc": any((e.get("title") or "").strip() for e in toc),
         "text_coverage": text_coverage_label(meta.get("text_coverage") or []),
+        "about": list(about or []),
         "size_bytes": meta["file_size"],
         "from_cache": from_cache,
     }

--- a/src/pdf_mcp/corpus.py
+++ b/src/pdf_mcp/corpus.py
@@ -41,6 +41,7 @@ __all__ = [
     "rrf_fuse_two_rankings_scored",
     "profile_terms",
     "build_doc_profile",
+    "backfill_doc_profiles",
 ]
 
 logger = logging.getLogger(__name__)
@@ -243,6 +244,48 @@ def build_doc_profile(
     if head.strip():
         vec = embed([head])[0]
     return vec, profile_terms(texts)
+
+
+def backfill_doc_profiles(
+    paths: list[str],
+    cache: Any,
+    model_name: str,
+    embed: Callable[[list[str]], list[bytes]],
+) -> int:
+    """Write profiles for warm docs that lack a valid one, from cached text.
+
+    Covers caches warmed before profiles existed, and model changes. Reads
+    only page_text (no PDF open, no page re-embed); one encode per doc
+    (batching measured no faster); all new rows in one transaction.
+    Returns how many rows were written. A doc whose encode raises is
+    logged and skipped so the rest still land.
+    """
+    have = cache.get_doc_profiles(paths, model_name)
+    pending = [p for p in paths if p not in have]
+    if not pending:
+        return 0
+    built: list[tuple[str, "bytes | None", dict[str, int]]] = []
+    for path in pending:
+        meta = cache.get_metadata(path)
+        if meta is None:
+            continue
+        texts = cache.get_pages_text(path, list(range(meta["page_count"])))
+        if not texts:
+            continue
+        try:
+            vec, terms = build_doc_profile(texts, embed)
+        except Exception as exc:  # noqa: BLE001 - never a search/warm error
+            logger.warning("doc profile backfill skipped %s: %s", path, exc)
+            continue
+        built.append((path, vec, terms))
+    if not built:
+        return 0
+    with cache.write_transaction() as conn:
+        for path, vec, terms in built:
+            cache.save_doc_profile(
+                path, PROFILE_HEAD_CHARS, vec, terms, model_name, conn=conn
+            )
+    return len(built)
 
 
 def _finalize_doc(
@@ -590,6 +633,18 @@ def warm_docs(
                 uncached.append((path, len(probe)))
         except Exception as e:
             skipped.append({"path": path, "reason": f"unreadable: {e}"})
+
+    # Profiles are new relative to existing caches: an explicit embeddings
+    # warm repairs coverage on docs that are otherwise fully cached, so a
+    # caller who warms gets the document arm without a search. Cheap
+    # (~17ms per doc) and never charged against the budget, like cached
+    # docs themselves.
+    if embeddings and embed is not None and model_name is not None:
+        cached_paths = [d["path"] for d in docs if d["status"] == "cached"]
+        try:
+            backfill_doc_profiles(cached_paths, cache, model_name, embed)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("doc profile backfill failed: %s", exc)
 
     uncached.sort(key=lambda item: item[1])
     workers = _warm_worker_count(len(uncached), embeddings)

--- a/src/pdf_mcp/corpus.py
+++ b/src/pdf_mcp/corpus.py
@@ -37,6 +37,7 @@ __all__ = [
     "text_coverage_label",
     "build_overview_card",
     "rrf_fuse_doc_rankings",
+    "rrf_fuse_rankings_scored",
     "rrf_fuse_two_rankings",
     "rrf_fuse_two_rankings_scored",
     "profile_terms",
@@ -801,24 +802,38 @@ def rrf_fuse_doc_rankings(
     return fused[:top_k] if top_k is not None else fused
 
 
+def rrf_fuse_rankings_scored(
+    rankings: list[tuple[list[tuple[str, int]], float]],
+    k: int = CORPUS_RRF_K,
+    top_k: int | None = None,
+) -> list[tuple[tuple[str, int], float]]:
+    """Weighted RRF across N global rankings, returning fused scores.
+
+    Each entry is (ranking, weight); an item's score is the sum of
+    weight / (k + rank) over every list it appears in (Cormack et al.
+    2009, with the per-list weight extension). Hybrid corpus search
+    passes [(keyword, 1.0), (semantic, 1.0), (doc_arm,
+    CORPUS_DOC_ARM_WEIGHT)]. Ties break by (doc_path, page), so a
+    document rename never reorders results except at exact ties.
+    """
+    scores: dict[tuple[str, int], float] = {}
+    for ranking, weight in rankings:
+        for rank, item in enumerate(ranking):
+            scores[item] = scores.get(item, 0.0) + weight / (k + rank)
+    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0][0], kv[0][1]))
+    return ordered[:top_k] if top_k is not None else ordered
+
+
 def rrf_fuse_two_rankings_scored(
     a: list[tuple[str, int]],
     b: list[tuple[str, int]],
     k: int = CORPUS_RRF_K,
     top_k: int | None = None,
 ) -> list[tuple[tuple[str, int], float]]:
-    """RRF across two global rankings (auto mode: keyword + semantic),
-    returning each item's fused score alongside it.
-
-    The same (doc_path, page) may appear in both lists; its RRF
-    contributions add. Ties break deterministically by (doc_path, page).
-    """
-    scores: dict[tuple[str, int], float] = {}
-    for ranking in (a, b):
-        for rank, item in enumerate(ranking):
-            scores[item] = scores.get(item, 0.0) + 1.0 / (k + rank)
-    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0][0], kv[0][1]))
-    return ordered[:top_k] if top_k is not None else ordered
+    """Two-list RRF at weight 1.0 each (single-doc hybrid and the keyword
+    paths). A wrapper over rrf_fuse_rankings_scored so both stay
+    byte-identical to the pre-document-arm fusion."""
+    return rrf_fuse_rankings_scored([(a, 1.0), (b, 1.0)], k=k, top_k=top_k)
 
 
 def rrf_fuse_two_rankings(

--- a/src/pdf_mcp/corpus.py
+++ b/src/pdf_mcp/corpus.py
@@ -10,7 +10,9 @@ caller; this module owns no storage of its own.
 
 from __future__ import annotations
 
+import logging
 import multiprocessing
+import re
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from concurrent.futures.process import BrokenProcessPool
@@ -26,6 +28,10 @@ from .parallel import resolve_workers
 __all__ = [
     "CORPUS_MAX_FILES",
     "CORPUS_RRF_K",
+    "CORPUS_DOC_ARM_WEIGHT",
+    "PROFILE_HEAD_CHARS",
+    "PROFILE_TERM_LIMIT",
+    "CORPUS_TERM_RE",
     "resolve_corpus",
     "warm_docs",
     "text_coverage_label",
@@ -33,7 +39,11 @@ __all__ = [
     "rrf_fuse_doc_rankings",
     "rrf_fuse_two_rankings",
     "rrf_fuse_two_rankings_scored",
+    "profile_terms",
+    "build_doc_profile",
 ]
+
+logger = logging.getLogger(__name__)
 
 # Hard ceiling on corpus size: the tens-of-docs design boundary made
 # explicit. Beyond this, corpus tools return an inline error instead
@@ -44,6 +54,21 @@ CORPUS_MAX_FILES = 100
 # fusion and single-doc hybrid fusion share one k. Design decided by the
 # stage-2 ranking benchmark: per-document fusion, not corpus-wide FTS.
 CORPUS_RRF_K = 60
+
+# Weight of the document arm in hybrid corpus fusion. Measured on the 500-doc
+# distractor rung (spike 2026-08-26, race 2): head vector at 0.25 and 0.5 are
+# indistinguishable (described hit@3 0.68, needle 1.000, trap 0.985); 0.25 is
+# the lighter touch and keeps 100-doc doc-NDCG flat. An equal-weight (1.0)
+# third list dilutes needles the page arms had already nailed. Not a tool
+# parameter: re-measure, never tune.
+CORPUS_DOC_ARM_WEIGHT = 0.25
+# Head text = page 1's first N characters: title, authors and abstract on
+# arXiv papers; cover plus summary on a 10-K. From the spike; not tuned.
+PROFILE_HEAD_CHARS = 1500
+PROFILE_TERM_LIMIT = 200
+# Latin word tokens. Shared with server._corpus_query_terms so profile terms
+# and query terms agree on what a term is; 4+ chars filters function words.
+CORPUS_TERM_RE = re.compile(r"[a-z0-9]+")
 
 # Concurrent-warm pool sizing (benchmark: warm_concurrency_results.md).
 # Below the gate, sequential is faster (spawn/IPC overhead outweighs the
@@ -190,6 +215,36 @@ def _cached_pages(
     return pages
 
 
+def profile_terms(texts: dict[int, str]) -> dict[str, int]:
+    """Top PROFILE_TERM_LIMIT tokens (4+ chars, lowercase) by count across
+    all pages. Ties break by term so the result is deterministic."""
+    counts: dict[str, int] = {}
+    for text in texts.values():
+        for tok in CORPUS_TERM_RE.findall(text.lower()):
+            if len(tok) > 3:
+                counts[tok] = counts.get(tok, 0) + 1
+    top = sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return dict(top[:PROFILE_TERM_LIMIT])
+
+
+def build_doc_profile(
+    texts: dict[int, str],
+    embed: Callable[[list[str]], list[bytes]],
+) -> "tuple[bytes | None, dict[str, int]]":
+    """The per-document profile: (head vector or None, term counts).
+
+    The head vector embeds page 1's first PROFILE_HEAD_CHARS characters
+    with the same callable used for pages, so it lives in the same space
+    as the page embeddings and the query. No text on page 1 means no
+    vector (None), never a vector of an empty string.
+    """
+    head = (texts.get(0) or "")[:PROFILE_HEAD_CHARS]
+    vec: bytes | None = None
+    if head.strip():
+        vec = embed([head])[0]
+    return vec, profile_terms(texts)
+
+
 def _finalize_doc(
     path: str,
     page_count: int,
@@ -239,6 +294,13 @@ def _finalize_doc(
 
     to_save = {pn: t for pn, t in texts.items() if pn not in preserved}
 
+    profile: "tuple[bytes | None, dict[str, int]] | None" = None
+    if embeddings and embed is not None and model_name is not None:
+        try:
+            profile = build_doc_profile(texts, embed)
+        except Exception as exc:  # noqa: BLE001 - profile is optional
+            logger.warning("doc profile skipped for %s: %s", path, exc)
+
     # ONE transaction for the whole document. Each of these writes used to
     # open its own connection, and leaving that block commits, which is an
     # fsync. Measured on same-spec CI runners, warming a 6-document corpus
@@ -256,6 +318,10 @@ def _finalize_doc(
         cache.save_pages_text(path, to_save, conn=conn)
         if blobs and model_name is not None:
             cache.save_page_embeddings(path, blobs, model_name, conn=conn)
+        if profile is not None and model_name is not None:
+            cache.save_doc_profile(
+                path, PROFILE_HEAD_CHARS, profile[0], profile[1], model_name, conn=conn
+            )
         if layout:
             # Written AFTER page_text: the hidden flag lives on page_text
             # rows, and blocks are keyed independently by mtime.

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -2962,7 +2962,11 @@ def pdf_corpus_overview(
         - docs: triage cards sorted by path {path, title, pages,
           toc_top (depth-1 titles, max 8), has_toc, text_coverage
           ("full"|"partial"|"none"), about (up to 8 distinctive terms,
-          [] when the doc has no profile yet), size_bytes, from_cache}
+          [] when the doc has no profile yet), size_bytes, from_cache}.
+          `about` is filled once the document has a profile, which is
+          written by `pdf_corpus_warm(paths, embeddings=True)` or by a
+          hybrid `pdf_corpus_search`; a text-only warm (the default
+          this tool itself calls) leaves it `[]`
         - unprocessed, skipped, corpus_size, warmed_this_call,
           budget_exhausted (same envelope as pdf_corpus_warm)
 
@@ -3450,7 +3454,10 @@ def pdf_corpus_search(
         - doc_profile_coverage: (hybrid only) {"profiled", "searched"};
           profiled < searched means the document arm ran partially
           (profiles still backfilling, or page 1 has no text); a
-          pdf_corpus_warm(embeddings=True) closes it
+          pdf_corpus_warm(embeddings=True) closes it. `profiled` counts
+          documents holding a head vector, which can exceed the
+          documents the arm actually ranked, since a doc can have a
+          profile but no page embeddings to anchor it to a result page
         - doc_score: (hybrid matches only) head-vector cosine of the
           match's document, 4 dp, null when the doc has no profile
         - all_results_low_confidence, confidence_threshold: semantic

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -2961,7 +2961,8 @@ def pdf_corpus_overview(
     Returns:
         - docs: triage cards sorted by path {path, title, pages,
           toc_top (depth-1 titles, max 8), has_toc, text_coverage
-          ("full"|"partial"|"none"), size_bytes, from_cache}
+          ("full"|"partial"|"none"), about (up to 8 distinctive terms,
+          [] when the doc has no profile yet), size_bytes, from_cache}
         - unprocessed, skipped, corpus_size, warmed_this_call,
           budget_exhausted (same envelope as pdf_corpus_warm)
 
@@ -2981,6 +2982,7 @@ def pdf_corpus_overview(
 
     warm = corpus.warm_docs(res["files"], budget, cache)
     skipped = list(res["skipped"]) + list(warm["skipped"])
+    about = corpus.about_terms(cache, [row["path"] for row in warm["docs"]])
     cards = []
     for row in warm["docs"]:
         if cache.get_metadata(row["path"]) is None:
@@ -2993,7 +2995,10 @@ def pdf_corpus_overview(
             continue
         cards.append(
             corpus.build_overview_card(
-                row["path"], cache, from_cache=row["status"] == "cached"
+                row["path"],
+                cache,
+                from_cache=row["status"] == "cached",
+                about=about.get(row["path"], []),
             )
         )
     cards.sort(key=lambda c: str(c["path"]))

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -3183,7 +3183,9 @@ def _corpus_keyword_rankings(
 
 
 def _merge_doc_match_counts(
-    kw_counts: dict[str, int], sem_ranking: list[tuple[str, int]]
+    kw_counts: dict[str, int],
+    sem_ranking: list[tuple[str, int]],
+    doc_list: list[tuple[str, int]] | None = None,
 ) -> dict[str, int]:
     """Per-doc match counts across BOTH hybrid arms.
 
@@ -3196,7 +3198,11 @@ def _merge_doc_match_counts(
 
     Counts are merged with max(), not sum: the two arms are separate views
     of the same pages, so the value means "at least this many pages in this
-    document matched", never a total of both views.
+    document matched", never a total of both views. The document arm names
+    documents the page arms may never have surfaced; that is the routing
+    gain, and doc_match_counts is the field the fan-out instruction sends
+    callers to, so it must be visible there. One document = at least one
+    matching page.
     """
     merged = dict(kw_counts)
     sem_counts: dict[str, int] = {}
@@ -3204,6 +3210,8 @@ def _merge_doc_match_counts(
         sem_counts[path] = sem_counts.get(path, 0) + 1
     for path, count in sem_counts.items():
         merged[path] = max(merged.get(path, 0), count)
+    for path, _page in doc_list or []:
+        merged[path] = max(merged.get(path, 0), 1)
     return merged
 
 
@@ -3240,6 +3248,28 @@ def _corpus_semantic_scores(
             vec = np.frombuffer(blob, dtype=np.float32).copy()
             scored.append((path, page_num + 1, float(vec @ query_vec)))
     return scored, semantic_unprocessed
+
+
+def _corpus_doc_scores(
+    paths: list[str],
+    model_name: str,
+    query_vec: Any,
+) -> dict[str, float]:
+    """Head-vector cosine per profiled document (the document arm).
+
+    One SELECT over doc_profiles, one matvec. Docs with a NULL vector
+    (page 1 empty) are excluded; the caller reports them through
+    `doc_profile_coverage`.
+    """
+    import numpy as np
+
+    profiles = cache.get_doc_profiles(paths, model_name)
+    keyed = [(p, blob) for p, blob in profiles.items() if blob is not None]
+    if not keyed:
+        return {}
+    mat = np.stack([np.frombuffer(blob, dtype=np.float32) for _p, blob in keyed])
+    sims = mat @ query_vec
+    return {p: float(s) for (p, _b), s in zip(keyed, sims)}
 
 
 def _group_excerpts_by_doc(
@@ -3412,6 +3442,12 @@ def pdf_corpus_search(
         - semantic_unprocessed: (semantic/hybrid only) paths that were
           warmed/cached but had no cached embeddings (e.g. warm raced
           the embeddings budget); additive to `unprocessed`
+        - doc_profile_coverage: (hybrid only) {"profiled", "searched"};
+          profiled < searched means the document arm ran partially
+          (profiles still backfilling, or page 1 has no text); a
+          pdf_corpus_warm(embeddings=True) closes it
+        - doc_score: (hybrid matches only) head-vector cosine of the
+          match's document, 4 dp, null when the doc has no profile
         - all_results_low_confidence, confidence_threshold: semantic
           and hybrid modes
         - model_name: semantic mode only
@@ -3635,6 +3671,7 @@ def pdf_corpus_search(
 
     # ── mode="auto" with embeddings available: hybrid fusion ──────────
     assert embed_model is not None  # guaranteed by check_available above
+    assert embed_fn is not None  # guaranteed by embeddings_needed above
     query_vec = _embedder.encode_query(query, embed_model)
     scored, semantic_unprocessed = _corpus_semantic_scores(
         ready_paths, embed_model, query_vec
@@ -3644,8 +3681,34 @@ def pdf_corpus_search(
     sem_limit = min(top_k * 3, len(scored))
     sem_ranking = [(path, page) for path, page, _s in scored[:sem_limit]]
 
-    fused_scored = corpus.rrf_fuse_two_rankings_scored(
-        kw_fused, sem_ranking, top_k=top_k
+    # ── document arm ──────────────────────────────────────────────────
+    # A third, weighted RRF list ranking DOCUMENTS by head-vector cosine,
+    # each mapped to its best semantic page. The page arms draw a 30-page
+    # shortlist from every page vector in the corpus, so under distractor
+    # pressure gold page-1s fall off it; one vector per document competes
+    # among N docs instead of N*pages. Measured: 500-doc described
+    # doc-hit@3 0.48 -> 0.68, needle/trap unchanged (spec 2026-08-26).
+    try:
+        corpus.backfill_doc_profiles(ready_paths, cache, embed_model, embed_fn)
+    except Exception as exc:  # noqa: BLE001 - arm runs on what it has
+        logger.warning("doc profile backfill failed: %s", exc)
+    doc_cos = _corpus_doc_scores(ready_paths, embed_model, query_vec)
+    best_page: dict[str, int] = {}
+    for path, page, _s in scored:  # already sorted best-first
+        best_page.setdefault(path, page)
+    doc_ranked = sorted(
+        ((p, c) for p, c in doc_cos.items() if p in best_page),
+        key=lambda t: (-t[1], t[0]),
+    )[: top_k * 3]
+    doc_list = [(p, best_page[p]) for p, _c in doc_ranked]
+
+    fused_scored = corpus.rrf_fuse_rankings_scored(
+        [
+            (kw_fused, 1.0),
+            (sem_ranking, 1.0),
+            (doc_list, corpus.CORPUS_DOC_ARM_WEIGHT),
+        ],
+        top_k=top_k,
     )
     fused = [item for item, _s in fused_scored]
     rrf_score_map = dict(fused_scored)
@@ -3673,6 +3736,7 @@ def pdf_corpus_search(
             "excerpt": excerpt,
             "score": round(rrf_score_map[(path, page)], 4),
             "semantic_score": round(sem_score, 4),
+            "doc_score": (round(doc_cos[path], 4) if path in doc_cos else None),
             "low_confidence": low_confidence,
             "position": 0,
             "_fused_pos": idx,
@@ -3689,7 +3753,13 @@ def pdf_corpus_search(
     return {
         "matches": matches,
         "total_matches": len(matches),
-        "doc_match_counts": _merge_doc_match_counts(kw_doc_match_counts, sem_ranking),
+        "doc_match_counts": _merge_doc_match_counts(
+            kw_doc_match_counts, sem_ranking, doc_list
+        ),
+        "doc_profile_coverage": {
+            "profiled": len(doc_cos),
+            "searched": len(ready_paths),
+        },
         "search_mode": "hybrid",
         "excerpt_style": excerpt_style,
         "coverage": {"searched": len(ready_paths), "corpus": len(res["files"])},

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -3035,7 +3035,7 @@ def _corpus_python_keyword_hits(
     return matches
 
 
-_CORPUS_TERM_RE = re.compile(r"[a-z0-9]+")
+_CORPUS_TERM_RE = corpus.CORPUS_TERM_RE
 
 
 def _corpus_query_terms(query: str) -> set[str]:

--- a/src/pdf_mcp/server.py
+++ b/src/pdf_mcp/server.py
@@ -3676,7 +3676,11 @@ def pdf_corpus_search(
 
     # ── mode="auto" with embeddings available: hybrid fusion ──────────
     assert embed_model is not None  # guaranteed by check_available above
-    assert embed_fn is not None  # guaranteed by embeddings_needed above
+    if embed_fn is None:
+        # embeddings_needed being true always sets embed_fn above; this
+        # branch is unreachable on the request path and exists so mypy
+        # can narrow embed_fn to non-None without an assert here.
+        raise RuntimeError("embed_fn unset despite embeddings_needed")
     query_vec = _embedder.encode_query(query, embed_model)
     scored, semantic_unprocessed = _corpus_semantic_scores(
         ready_paths, embed_model, query_vec

--- a/tests/data/demo_fusion_fixtures.json
+++ b/tests/data/demo_fusion_fixtures.json
@@ -222,7 +222,53 @@
     "expected": {
       "x.pdf": 1.6094379124341005,
       "y.pdf": 0.6931471805599453,
-      "z.pdf": 2.9957322735539913
+      "z.pdf": 2.995732273553991
+    }
+  },
+  "about_terms": {
+    "docs": {
+      "/a.pdf": {
+        "0": "the cat budget budget alpha",
+        "1": "Alpha REPORT"
+      },
+      "/b.pdf": {
+        "0": "bravo budget report report"
+      },
+      "/c.pdf": {
+        "0": "charlie budget"
+      }
+    },
+    "expected_terms": {
+      "/a.pdf": {
+        "alpha": 2,
+        "budget": 2,
+        "report": 1
+      },
+      "/b.pdf": {
+        "report": 2,
+        "bravo": 1,
+        "budget": 1
+      },
+      "/c.pdf": {
+        "budget": 1,
+        "charlie": 1
+      }
+    },
+    "expected_about": {
+      "/a.pdf": [
+        "alpha",
+        "budget",
+        "report"
+      ],
+      "/b.pdf": [
+        "report",
+        "bravo",
+        "budget"
+      ],
+      "/c.pdf": [
+        "charlie",
+        "budget"
+      ]
     }
   },
   "end_to_end": {

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -919,6 +919,58 @@ class TestCorpusFusion:
         scored = corpus.rrf_fuse_two_rankings_scored(a, b)
         assert [item for item, _s in scored] == corpus.rrf_fuse_two_rankings(a, b)
 
+    def test_n_rankings_weight_scales_contribution(self):
+        kw = [("a.pdf", 1)]
+        sem = [("b.pdf", 2)]
+        doc = [("c.pdf", 3)]
+        scored = dict(
+            corpus.rrf_fuse_rankings_scored([(kw, 1.0), (sem, 1.0), (doc, 0.25)])
+        )
+        k = corpus.CORPUS_RRF_K
+        assert scored[("a.pdf", 1)] == 1.0 / k
+        assert scored[("c.pdf", 3)] == 0.25 / k
+
+    def test_n_rankings_two_lists_at_weight_one_is_byte_identical(self):
+        a = [("x.pdf", 1), ("y.pdf", 2), ("q.pdf", 9)]
+        b = [("y.pdf", 2), ("z.pdf", 3), ("x.pdf", 1)]
+        assert corpus.rrf_fuse_rankings_scored(
+            [(a, 1.0), (b, 1.0)], top_k=3
+        ) == corpus.rrf_fuse_two_rankings_scored(a, b, top_k=3)
+
+    def test_n_rankings_reproduces_spike_fusion(self):
+        # Hand-checked against docprofile_race2.fuse_weighted (k=60):
+        # y: 1/61 + 1/60            = 0.033060...
+        # x: 1/60 + 0.25/60         = 0.020833...
+        # z: 1/61 + 0.25/61         = 0.020491...
+        kw = [("x.pdf", 1), ("y.pdf", 2)]
+        sem = [("y.pdf", 2), ("z.pdf", 3)]
+        doc = [("x.pdf", 1), ("z.pdf", 3)]
+        fused = [
+            it
+            for it, _s in corpus.rrf_fuse_rankings_scored(
+                [(kw, 1.0), (sem, 1.0), (doc, 0.25)]
+            )
+        ]
+        assert fused == [("y.pdf", 2), ("x.pdf", 1), ("z.pdf", 3)]
+
+    def test_n_rankings_invariant_under_document_renaming(self):
+        kw = [("a.pdf", 1), ("m.pdf", 2)]
+        sem = [("z.pdf", 3), ("a.pdf", 1)]
+        doc = [("m.pdf", 2), ("z.pdf", 3)]
+        rename = {"a.pdf": "z9.pdf", "m.pdf": "m9.pdf", "z.pdf": "a9.pdf"}
+        ren = lambda lst: [(rename[d], p) for d, p in lst]  # noqa: E731
+        base = corpus.rrf_fuse_rankings_scored([(kw, 1.0), (sem, 1.0), (doc, 0.25)])
+        moved = corpus.rrf_fuse_rankings_scored(
+            [(ren(kw), 1.0), (ren(sem), 1.0), (ren(doc), 0.25)]
+        )
+        assert [(rename[d], p) for (d, p), _s in base] == [it for it, _s in moved]
+
+    def test_n_rankings_exact_tie_breaks_by_path_then_page(self):
+        scored = corpus.rrf_fuse_rankings_scored(
+            [([("z.pdf", 1)], 1.0), ([("a.pdf", 2)], 1.0), ([], 0.25)]
+        )
+        assert [it for it, _s in scored] == [("a.pdf", 2), ("z.pdf", 1)]
+
 
 class TestWarmExtractWorker:
     def test_payload_shape(self, corpus_dir):

--- a/tests/test_doc_profiles.py
+++ b/tests/test_doc_profiles.py
@@ -1,0 +1,83 @@
+"""Document profiles: the cached per-doc head vector + term counts that
+back the hybrid corpus search's document arm and overview `about`."""
+
+import os
+import time
+
+import numpy as np
+import pymupdf
+import pytest
+
+from pdf_mcp.cache import PDFCache
+
+
+def _make_pdf(path, pages):
+    doc = pymupdf.open()
+    for text in pages:
+        page = doc.new_page()
+        page.insert_text((50, 50), text, fontsize=11)
+    doc.save(str(path))
+    doc.close()
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return PDFCache(cache_dir=tmp_path / "cache", ttl_hours=1)
+
+
+@pytest.fixture
+def pdf(tmp_path):
+    p = tmp_path / "doc.pdf"
+    _make_pdf(p, ["alpha budget report", "second page budget"])
+    return str(p)
+
+
+class TestDocProfileTable:
+    def test_round_trip_vector_and_terms(self, cache, pdf):
+        vec = np.array([1.0, 0.0], dtype=np.float32).tobytes()
+        cache.save_doc_profile(pdf, 1500, vec, {"budget": 2, "report": 1}, "m1")
+        assert cache.get_doc_profiles([pdf], "m1") == {pdf: vec}
+        assert cache.get_doc_terms([pdf]) == {pdf: {"budget": 2, "report": 1}}
+
+    def test_null_vector_row_is_valid_but_none(self, cache, pdf):
+        cache.save_doc_profile(pdf, 1500, None, {}, "m1")
+        assert cache.get_doc_profiles([pdf], "m1") == {pdf: None}
+
+    def test_model_mismatch_is_absent(self, cache, pdf):
+        cache.save_doc_profile(pdf, 1500, b"\x00" * 8, {"x": 1}, "m1")
+        assert cache.get_doc_profiles([pdf], "m2") == {}
+        # terms are model-independent
+        assert pdf in cache.get_doc_terms([pdf])
+
+    def test_stale_mtime_is_absent(self, cache, pdf):
+        cache.save_doc_profile(pdf, 1500, b"\x00" * 8, {"x": 1}, "m1")
+        future = time.time() + 5
+        os.utime(pdf, (future, future))
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.get_doc_terms([pdf]) == {}
+
+    def test_replace_overwrites(self, cache, pdf):
+        cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1")
+        cache.save_doc_profile(pdf, 1500, b"\x02" * 8, {"b": 1}, "m2")
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.get_doc_profiles([pdf], "m2") == {pdf: b"\x02" * 8}
+        assert cache.get_doc_terms([pdf]) == {pdf: {"b": 1}}
+
+    def test_missing_file_is_skipped_not_raised(self, cache, tmp_path):
+        assert cache.get_doc_profiles([str(tmp_path / "ghost.pdf")], "m1") == {}
+        assert cache.get_doc_terms([str(tmp_path / "ghost.pdf")]) == {}
+
+    def test_write_inside_caller_transaction(self, cache, pdf):
+        with cache.write_transaction() as conn:
+            cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1", conn=conn)
+        assert pdf in cache.get_doc_profiles([pdf], "m1")
+
+    def test_dropped_on_extraction_version_bump(self, cache, pdf, tmp_path):
+        import sqlite3
+
+        cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1")
+        # Simulate an older extraction version on disk, then reopen.
+        with sqlite3.connect(cache.db_path) as conn:
+            conn.execute("PRAGMA user_version = 1")
+        reopened = PDFCache(cache_dir=tmp_path / "cache", ttl_hours=1)
+        assert reopened.get_doc_profiles([pdf], "m1") == {}

--- a/tests/test_doc_profiles.py
+++ b/tests/test_doc_profiles.py
@@ -237,3 +237,44 @@ class TestBackfill:
         )
         assert out["docs"][0]["status"] == "cached"
         assert pdf in cache.get_doc_profiles([pdf], "m1")
+
+
+class TestAboutTerms:
+    def test_distinctive_terms_rank_first(self, cache, tmp_path):
+        paths = []
+        for name, terms in [
+            ("a.pdf", {"shared": 9, "alpha": 3}),
+            ("b.pdf", {"shared": 9, "bravo": 3}),
+            ("c.pdf", {"shared": 9, "charlie": 3}),
+        ]:
+            p = tmp_path / name
+            _make_pdf(p, ["x"])
+            cache.save_doc_profile(str(p), 1500, None, terms, "m1")
+            paths.append(str(p))
+        about = corpus.about_terms(cache, paths)
+        # shared: 9*log(1+3/3)=6.24 ; alpha: 3*log(1+3/1)=4.16 -> shared first
+        assert about[paths[0]] == ["shared", "alpha"]
+        assert about[paths[1]] == ["shared", "bravo"]
+
+    def test_limit_and_unprofiled(self, cache, tmp_path):
+        p = tmp_path / "a.pdf"
+        _make_pdf(p, ["x"])
+        cache.save_doc_profile(
+            str(p), 1500, None, {f"term{i:02d}": 1 for i in range(20)}, "m1"
+        )
+        q = tmp_path / "b.pdf"
+        _make_pdf(q, ["x"])
+        about = corpus.about_terms(cache, [str(p), str(q)])
+        assert len(about[str(p)]) == 8
+        assert about[str(q)] == []
+
+    def test_card_carries_about(self, cache, pdf):
+        corpus.warm_docs(
+            [pdf], 600, cache, embeddings=True, model_name="m1", embed=_embed_len
+        )
+        about = corpus.about_terms(cache, [pdf])
+        card = corpus.build_overview_card(pdf, cache, from_cache=True, about=about[pdf])
+        assert card["about"] == about[pdf]
+        assert "budget" in card["about"]
+        bare = corpus.build_overview_card(pdf, cache, from_cache=True)
+        assert bare["about"] == []

--- a/tests/test_doc_profiles.py
+++ b/tests/test_doc_profiles.py
@@ -157,3 +157,83 @@ class TestProfileWrittenAtWarm:
         assert out["warmed_this_call"] == 1
         assert cache.get_doc_profiles([pdf], "m1") == {}
         assert cache.embeddings_complete(pdf, "m1")
+
+
+class TestBackfill:
+    def _warm_text_only(self, cache, paths):
+        corpus.warm_docs(paths, 600, cache, embeddings=False, model_name="m1")
+
+    def test_backfills_exactly_the_missing_docs(self, cache, tmp_path):
+        a, b = tmp_path / "a.pdf", tmp_path / "b.pdf"
+        _make_pdf(a, ["alpha budget"])
+        _make_pdf(b, ["bravo budget"])
+        paths = [str(a), str(b)]
+        self._warm_text_only(cache, paths)
+        cache.save_doc_profile(str(a), 1500, b"\x01" * 8, {"alpha": 1}, "m1")
+        seen = []
+
+        def spy(texts):
+            seen.extend(texts)
+            return _embed_len(texts)
+
+        n = corpus.backfill_doc_profiles(paths, cache, "m1", spy)
+        assert n == 1
+        # Only b.pdf's head was encoded; a.pdf already had a valid row.
+        assert len(seen) == 1 and "bravo" in seen[0] and "alpha" not in seen[0]
+        assert set(cache.get_doc_profiles(paths, "m1")) == set(paths)
+
+    def test_full_coverage_writes_nothing(self, cache, pdf):
+        self._warm_text_only(cache, [pdf])
+        corpus.backfill_doc_profiles([pdf], cache, "m1", _embed_len)
+
+        def boom(texts):
+            raise AssertionError("no encode expected")
+
+        assert corpus.backfill_doc_profiles([pdf], cache, "m1", boom) == 0
+
+    def test_empty_page1_row_is_written_once(self, cache, tmp_path):
+        p = tmp_path / "blank.pdf"
+        _make_pdf(p, ["", "budget on page two"])
+        self._warm_text_only(cache, [str(p)])
+        assert corpus.backfill_doc_profiles([str(p)], cache, "m1", _embed_len) == 1
+        assert cache.get_doc_profiles([str(p)], "m1") == {str(p): None}
+        assert corpus.backfill_doc_profiles([str(p)], cache, "m1", _embed_len) == 0
+
+    def test_model_change_rewrites(self, cache, pdf):
+        self._warm_text_only(cache, [pdf])
+        corpus.backfill_doc_profiles([pdf], cache, "m1", _embed_len)
+        assert corpus.backfill_doc_profiles([pdf], cache, "m2", _embed_len) == 1
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+
+    def test_unwarmed_doc_is_skipped(self, cache, pdf):
+        assert corpus.backfill_doc_profiles([pdf], cache, "m1", _embed_len) == 0
+
+    def test_one_failing_encode_does_not_block_the_rest(self, cache, tmp_path):
+        a, b = tmp_path / "a.pdf", tmp_path / "b.pdf"
+        _make_pdf(a, ["alpha budget"])
+        _make_pdf(b, ["bravo budget"])
+        paths = [str(a), str(b)]
+        self._warm_text_only(cache, paths)
+
+        def flaky(texts):
+            if "alpha" in texts[0]:
+                raise RuntimeError("nope")
+            return _embed_len(texts)
+
+        assert corpus.backfill_doc_profiles(paths, cache, "m1", flaky) == 1
+        assert list(cache.get_doc_profiles(paths, "m1")) == [str(b)]
+
+    def test_warm_with_embeddings_backfills_cached_docs(self, cache, pdf):
+        self._warm_text_only(cache, [pdf])
+        out = corpus.warm_docs(
+            [pdf], 600, cache, embeddings=True, model_name="m1", embed=_embed_len
+        )
+        # doc was text-warm but had no embeddings, so it re-warms with them
+        assert pdf in cache.get_doc_profiles([pdf], "m1")
+        # now fully cached: a second embeddings warm still repairs a lost profile
+        cache.save_doc_profile(pdf, 1500, b"\x00" * 8, {}, "other-model")
+        out = corpus.warm_docs(
+            [pdf], 600, cache, embeddings=True, model_name="m1", embed=_embed_len
+        )
+        assert out["docs"][0]["status"] == "cached"
+        assert pdf in cache.get_doc_profiles([pdf], "m1")

--- a/tests/test_doc_profiles.py
+++ b/tests/test_doc_profiles.py
@@ -8,6 +8,7 @@ import numpy as np
 import pymupdf
 import pytest
 
+from pdf_mcp import corpus
 from pdf_mcp.cache import PDFCache
 
 
@@ -81,3 +82,78 @@ class TestDocProfileTable:
             conn.execute("PRAGMA user_version = 1")
         reopened = PDFCache(cache_dir=tmp_path / "cache", ttl_hours=1)
         assert reopened.get_doc_profiles([pdf], "m1") == {}
+
+
+def _embed_len(texts):
+    """Deterministic fake: unit vector keyed on text length parity."""
+    out = []
+    for t in texts:
+        v = np.array([1.0, float(len(t) % 2)], dtype=np.float32)
+        out.append((v / np.linalg.norm(v)).tobytes())
+    return out
+
+
+class TestBuildDocProfile:
+    def test_head_is_page1_first_1500_chars(self):
+        seen = []
+
+        def spy(texts):
+            seen.extend(texts)
+            return _embed_len(texts)
+
+        texts = {0: "x" * 2000, 1: "ignored"}
+        vec, _terms = corpus.build_doc_profile(texts, spy)
+        assert seen == ["x" * 1500]
+        assert vec is not None
+
+    def test_empty_page1_gives_no_vector_and_no_encode(self):
+        def boom(texts):
+            raise AssertionError("must not encode an empty head")
+
+        vec, terms = corpus.build_doc_profile({0: "   ", 1: "budget budget"}, boom)
+        assert vec is None
+        assert terms == {"budget": 2}
+
+    def test_terms_are_4plus_chars_across_all_pages_capped(self):
+        texts = {0: "the cat budget", 1: "Budget REPORT report a"}
+        _vec, terms = corpus.build_doc_profile(texts, _embed_len)
+        assert terms == {"budget": 2, "report": 2}
+        many = {0: " ".join(f"term{i:04d}" for i in range(500))}
+        _vec, terms = corpus.build_doc_profile(many, _embed_len)
+        assert len(terms) == corpus.PROFILE_TERM_LIMIT
+
+    def test_constants(self):
+        assert corpus.CORPUS_DOC_ARM_WEIGHT == 0.25
+        assert corpus.PROFILE_HEAD_CHARS == 1500
+        assert corpus.CORPUS_TERM_RE.findall("a1 b-c") == ["a1", "b", "c"]
+
+
+class TestProfileWrittenAtWarm:
+    def test_profile_lands_with_pages(self, cache, pdf):
+        corpus.warm_docs(
+            [pdf], 600, cache, embeddings=True, model_name="m1", embed=_embed_len
+        )
+        prof = cache.get_doc_profiles([pdf], "m1")
+        assert pdf in prof and prof[pdf] is not None
+        assert "budget" in cache.get_doc_terms([pdf])[pdf]
+
+    def test_text_only_warm_writes_no_profile(self, cache, pdf):
+        corpus.warm_docs([pdf], 600, cache, embeddings=False, model_name="m1")
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+
+    def test_encode_failure_is_not_a_warm_failure(self, cache, pdf):
+        calls = {"n": 0}
+
+        def flaky(texts):
+            calls["n"] += 1
+            if calls["n"] == 2:  # first call embeds pages, second is the head
+                raise RuntimeError("encoder hiccup")
+            return _embed_len(texts)
+
+        out = corpus.warm_docs(
+            [pdf], 600, cache, embeddings=True, model_name="m1", embed=flaky
+        )
+        assert out["skipped"] == []
+        assert out["warmed_this_call"] == 1
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.embeddings_complete(pdf, "m1")

--- a/tests/test_doc_profiles.py
+++ b/tests/test_doc_profiles.py
@@ -83,6 +83,37 @@ class TestDocProfileTable:
         reopened = PDFCache(cache_dir=tmp_path / "cache", ttl_hours=1)
         assert reopened.get_doc_profiles([pdf], "m1") == {}
 
+    def test_invalidate_removes_profile(self, cache, pdf):
+        """_invalidate_file must clear doc_profiles along with the rest of
+        the per-file cache, not just page_text/page_embeddings."""
+        cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1")
+        cache._invalidate_file(pdf)
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.get_doc_terms([pdf]) == {}
+
+    def test_clear_all_removes_profile(self, cache, pdf):
+        cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1")
+        cache.clear_all()
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.get_doc_terms([pdf]) == {}
+
+    def test_clear_expired_removes_profile(self, cache, pdf):
+        cache.save_metadata(pdf, 1, {}, [])
+        cache.save_doc_profile(pdf, 1500, b"\x01" * 8, {"a": 1}, "m1")
+
+        import sqlite3
+
+        with sqlite3.connect(cache.db_path) as conn:
+            conn.execute(
+                "UPDATE pdf_metadata SET accessed_at = '2000-01-01'"
+                " WHERE file_path = ?",
+                (pdf,),
+            )
+
+        cache.clear_expired()
+        assert cache.get_doc_profiles([pdf], "m1") == {}
+        assert cache.get_doc_terms([pdf]) == {}
+
 
 def _embed_len(texts):
     """Deterministic fake: unit vector keyed on text length parity."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4621,6 +4621,74 @@ class TestPdfCorpusSearchSemanticAuto:
         result = pdf_corpus_search(str(corpus_dir), "budget", mode="semantic")
         assert "error" in result
 
+    def test_hybrid_carries_doc_arm_fields(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        result = pdf_corpus_search(str(corpus_dir), "budget", mode="auto")
+        assert result["search_mode"] == "hybrid"
+        cov = result["doc_profile_coverage"]
+        assert cov == {"profiled": 3, "searched": 3}
+        for m in result["matches"]:
+            assert "doc_score" in m
+            assert m["doc_score"] is None or isinstance(m["doc_score"], float)
+        assert any(m["doc_score"] is not None for m in result["matches"])
+
+    def test_hybrid_backfills_profiles_on_a_pre_existing_cache(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        cache, _ = isolated_server
+        # Warm with embeddings, then delete the profiles to simulate a cache
+        # written before profiles existed.
+        pdf_corpus_warm(str(corpus_dir), embeddings=True)
+        import sqlite3
+
+        with sqlite3.connect(cache.db_path) as conn:
+            conn.execute("DELETE FROM doc_profiles")
+        result = pdf_corpus_search(str(corpus_dir), "budget", mode="auto")
+        assert result["doc_profile_coverage"]["profiled"] == 3
+
+    def test_doc_score_is_null_for_an_unprofiled_doc(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        cache, _ = isolated_server
+        pdf_corpus_search(str(corpus_dir), "budget", mode="auto")
+        alpha = str(corpus_dir / "alpha.pdf")
+        # A valid row with a NULL vector means "page 1 had no text": the
+        # backfill must not re-encode it, and its matches score null.
+        cache.save_doc_profile(alpha, 1500, None, {}, server.pdf_config.embedding_model)
+        result = pdf_corpus_search(str(corpus_dir), "budget", mode="auto", top_k=20)
+        assert result["doc_profile_coverage"] == {"profiled": 2, "searched": 3}
+        alpha_hits = [m for m in result["matches"] if m["path"] == alpha]
+        assert alpha_hits and all(m["doc_score"] is None for m in alpha_hits)
+
+    def test_doc_arm_docs_appear_in_doc_match_counts(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        result = pdf_corpus_search(str(corpus_dir), "budget", mode="auto")
+        for m in result["matches"]:
+            assert result["doc_match_counts"].get(m["path"], 0) >= 1
+
+    def test_keyword_and_semantic_responses_have_no_doc_arm_fields(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        for mode in ("keyword", "semantic"):
+            result = pdf_corpus_search(str(corpus_dir), "budget", mode=mode)
+            assert "doc_profile_coverage" not in result
+            assert not any("doc_score" in m for m in result["matches"])
+
+    def test_single_doc_pdf_search_hybrid_unchanged(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        self._fake_embedder(monkeypatch)
+        single = pdf_search(str(corpus_dir / "alpha.pdf"), "budget", mode="auto")
+        assert "doc_profile_coverage" not in single
+        assert not any("doc_score" in m for m in single["matches"])
+
 
 class TestPdfCorpusSearchSourceLabel:
     """Corpus hits report real per-page text provenance ('ocr' vs

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4383,6 +4383,7 @@ class TestPdfCorpusOverview:
             "toc_top",
             "has_toc",
             "text_coverage",
+            "about",
             "size_bytes",
             "from_cache",
         }
@@ -4428,6 +4429,17 @@ class TestPdfCorpusOverview:
         card_paths = [c["path"] for c in result["docs"]]
         assert target_path not in card_paths
         assert len(result["docs"]) == 2
+
+    def test_cards_carry_about(self, corpus_dir, isolated_server, monkeypatch):
+        TestPdfCorpusSearchSemanticAuto._fake_embedder(monkeypatch)
+        pdf_corpus_warm(str(corpus_dir), embeddings=True)
+        result = pdf_corpus_overview(str(corpus_dir))
+        assert all(isinstance(c["about"], list) for c in result["docs"])
+        assert any("budget" in c["about"] for c in result["docs"])
+
+    def test_about_is_empty_list_without_profiles(self, corpus_dir, isolated_server):
+        result = pdf_corpus_overview(str(corpus_dir))
+        assert all(c["about"] == [] for c in result["docs"])
 
 
 class TestPdfCorpusSearchKeyword:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4689,6 +4689,82 @@ class TestPdfCorpusSearchSemanticAuto:
         assert "doc_profile_coverage" not in single
         assert not any("doc_score" in m for m in single["matches"])
 
+    def test_hybrid_wires_doc_arm_into_rrf_fusion(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        """Pins the call site at server.py: three arms, in order, at
+        weights (1.0, 1.0, CORPUS_DOC_ARM_WEIGHT); a substituted weight
+        or a swapped list here would slip past every other test."""
+        self._fake_embedder(monkeypatch)
+        cache, _ = isolated_server
+        top_k = 10
+
+        real_fuse = server.corpus.rrf_fuse_rankings_scored
+        captured: dict[str, Any] = {}
+
+        def spy(rankings, k=server.corpus.CORPUS_RRF_K, top_k=None):
+            captured["rankings"] = rankings
+            return real_fuse(rankings, k=k, top_k=top_k)
+
+        monkeypatch.setattr(server.corpus, "rrf_fuse_rankings_scored", spy)
+
+        result = pdf_corpus_search(str(corpus_dir), "budget", mode="auto", top_k=top_k)
+        assert result["search_mode"] == "hybrid"
+
+        rankings = captured["rankings"]
+        assert len(rankings) == 3
+        weights = tuple(w for _list, w in rankings)
+        assert weights == (1.0, 1.0, server.corpus.CORPUS_DOC_ARM_WEIGHT)
+        kw_list, sem_list, doc_list = (r for r, _w in rankings)
+
+        # Third arm: one best page per profiled doc, no duplicate docs.
+        assert doc_list
+        assert all(isinstance(page, int) and page >= 1 for _p, page in doc_list)
+        assert len(doc_list) == len({p for p, _pg in doc_list})
+        profiled = cache.get_doc_profiles(
+            [p for p, _pg in doc_list], server.pdf_config.embedding_model
+        )
+        assert all(profiled.get(p) is not None for p, _pg in doc_list)
+
+        # First arm: byte-identical to the keyword-only fused ranking a
+        # plain keyword search produces for the same query and top_k.
+        kw_result = pdf_corpus_search(
+            str(corpus_dir), "budget", mode="keyword", top_k=top_k
+        )
+        kw_order = [(m["path"], m["page"]) for m in kw_result["matches"]]
+        assert kw_list == kw_order
+
+        # Second arm: a page-level shortlist, strictly larger than the
+        # doc-level one (distinguishes it from the doc arm at a glance).
+        assert len(sem_list) > len(doc_list)
+        assert all(isinstance(page, int) and page >= 1 for _p, page in sem_list)
+
+    def test_doc_arm_changes_the_fused_order(
+        self, corpus_dir, isolated_server, monkeypatch
+    ):
+        """corpus_dir's three docs carry identical per-page 'budget'
+        counts, so keyword+semantic alone tie every page and the RRF
+        tie-break (alphabetical path) always puts alpha.pdf first. A
+        document arm that favours charlie.pdf (alphabetically last)
+        must be able to overturn that tie; an arm that never runs
+        (empty doc_cos) must not."""
+        self._fake_embedder(monkeypatch)
+        charlie = str(corpus_dir / "charlie.pdf")
+
+        def favor_charlie(paths, model_name, query_vec):
+            return {charlie: 5.0}
+
+        monkeypatch.setattr(server, "_corpus_doc_scores", favor_charlie)
+        favored = pdf_corpus_search(str(corpus_dir), "budget", mode="auto", top_k=10)
+        assert favored["matches"][0]["path"] == charlie
+
+        def no_doc_arm(paths, model_name, query_vec):
+            return {}
+
+        monkeypatch.setattr(server, "_corpus_doc_scores", no_doc_arm)
+        unfavored = pdf_corpus_search(str(corpus_dir), "budget", mode="auto", top_k=10)
+        assert unfavored["matches"][0]["path"] != charlie
+
 
 class TestPdfCorpusSearchSourceLabel:
     """Corpus hits report real per-page text provenance ('ocr' vs


### PR DESCRIPTION
Hybrid `pdf_corpus_search` now ranks documents as well as pages. Each document gets a cached profile (an embedding of the first 1,500 characters of page 1, plus term counts), written in the same transaction as its pages and backfilled from cached text for older caches. Profiled documents are scored by cosine against the query, mapped to their best semantic page, and fused as a third RRF list at weight 0.25 next to the keyword and semantic arms. Hybrid hits carry `doc_score`, the response carries `doc_profile_coverage`, and `pdf_corpus_overview` cards carry `about`. Keyword mode, semantic mode, and single-document `pdf_search` are unchanged byte for byte.

The reason: on the 500-document rung (100 graded arXiv papers plus 400 distractors), described-query doc-hit@3 fell from 0.72 to 0.48 because the router only knew about pages. That held the corpus cap on 2026-08-24.

| corpus | described doc-hit@3 | spread doc-hit@3 | needle / trap doc-NDCG |
|---|---|---|---|
| 500 docs, before | 0.48 | 0.64 | 1.000 / 0.985 |
| 500 docs, after | 0.68 | 0.72 | 1.000 / 0.985 |

The keyword and semantic arms scored the same on every query in both runs, so the difference is the arm. Latency is 3.0 s/query against a 5 s gate.

A sweep from 50 to 500 documents (`benchmark_data/corpus_search/doc_arm_size_sweep.md`) shows described doc-hit@3 holding at 0.64 to 0.72 with the arm where it decays to 0.48 without it; needle and trap never move. The one cost is a single spread query on corpora of 100 or fewer, a paper the query only matches deep inside while its abstract is about something else. No fusion shape or weight removes that loss without removing the gain, so a size gate is backlogged rather than built. The 10-K corpus moved by at most one query per class and the excerpt gate exits 0.

Also here: a weighted N-list RRF (`corpus.rrf_fuse_rankings_scored`, with the old two-list function as a wrapper), `doc_profiles` cleared by `invalidate`, `clear_expired`, and `clear_all`, a harness fix so symlinked paths no longer grade as 0.000, and regenerated results files with corrected narratives.

Not here: `CORPUS_MAX_FILES` stays 100. Raising it waits on a defect found during this work, where `pdf_corpus_warm` reported `unprocessed: []` with 21 of 500 documents unwarmed. `about` fills only after an embeddings warm or a hybrid search; a text-only warm leaves it empty.

1761 tests pass, demo parity exit 0, flake8 and mypy clean, rebased on `develop` at c4f16c9.
